### PR TITLE
feat: generate named union enums

### DIFF
--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -659,6 +659,7 @@ struct UnionDef {
 
 struct UnionVariant {
     name: String,
+    original_name: Option<String>,
     ty: String,
 }
 
@@ -705,7 +706,14 @@ fn gen_unions(unions: &UnionRegistry) -> String {
             let variants = union
                 .variants
                 .iter()
-                .map(|variant| format!("    {}({}),", variant.name, variant.ty))
+                .map(|variant| {
+                    let original_name = variant
+                        .original_name
+                        .as_ref()
+                        .map(|name| format!("    /// `{name}`.\n"))
+                        .unwrap_or_default();
+                    format!("{original_name}    {}({}),", variant.name, variant.ty)
+                })
                 .join("\n");
             format!(
                 "{}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}",
@@ -748,23 +756,20 @@ fn gen_type_def(
             if items.len() == 1 {
                 gen_type_def(items.first().unwrap(), unions, name_hint, proposed, documentation)
             } else {
-                let variant_names = items
-                    .iter()
-                    .map(gen_variant_name)
-                    .enumerate()
-                    .fold(IndexSet::new(), |mut names, (index, name)| {
-                        let name = unique_variant_name(&names, name, index);
-                        names.insert(name);
-                        names
-                    })
-                    .into_iter()
-                    .collect::<Vec<_>>();
+                let original_variant_names = items.iter().map(gen_variant_name).collect::<Vec<_>>();
+                let variant_names = shorten_variant_names(original_variant_names.clone());
                 let variants = items
                     .iter()
+                    .zip(original_variant_names)
                     .zip(variant_names)
-                    .map(|(item, variant_name)| {
+                    .map(|((item, original_name), variant_name)| {
                         let ty = gen_type_def(item, unions, &format!("{name_hint}{variant_name}"), proposed, None);
-                        UnionVariant { name: variant_name, ty }
+                        let original_name = (original_name != variant_name).then_some(original_name);
+                        UnionVariant {
+                            name: variant_name,
+                            original_name,
+                            ty,
+                        }
                     })
                     .collect();
                 unions.push(name_hint.to_upper_camel_case(), variants, documentation, proposed)
@@ -835,6 +840,118 @@ fn gen_variant_name(type_def: &TypeDef) -> String {
         TypeDef::StringLiteral => "String".into(),
         _ => unreachable!(),
     }
+}
+
+fn shorten_variant_names(names: Vec<String>) -> Vec<String> {
+    let segments = names
+        .iter()
+        .map(|name| split_upper_camel_case(name))
+        .collect::<Vec<_>>();
+    let named_variant_indices = names
+        .iter()
+        .enumerate()
+        .filter_map(|(index, name)| (!is_base_variant_name(name)).then_some(index))
+        .collect::<Vec<_>>();
+    let candidate_segments = shortened_variant_segments(&segments, &named_variant_indices);
+
+    names
+        .into_iter()
+        .enumerate()
+        .fold(IndexSet::new(), |mut shortened_names, (index, name)| {
+            let candidate = candidate_segments
+                .as_ref()
+                .and_then(|segments| segments.get(&index))
+                .map(|segments| segments.concat())
+                .unwrap_or(name);
+            let name = unique_variant_name(&shortened_names, candidate, index);
+            shortened_names.insert(name);
+            shortened_names
+        })
+        .into_iter()
+        .collect()
+}
+
+fn shortened_variant_segments(
+    segments: &[Vec<String>],
+    indices: &[usize],
+) -> Option<std::collections::HashMap<usize, Vec<String>>> {
+    if indices.len() < 2 {
+        return None;
+    }
+
+    let selected = indices
+        .iter()
+        .map(|index| segments[*index].as_slice())
+        .collect::<Vec<_>>();
+    let prefix_len = common_prefix_len_all(&selected);
+    if prefix_len == 0 || selected.iter().any(|segments| prefix_len >= segments.len()) {
+        return None;
+    }
+
+    let mut shortened = indices
+        .iter()
+        .map(|index| (*index, segments[*index][prefix_len..].to_vec()))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    let selected = shortened.values().map(Vec::as_slice).collect::<Vec<_>>();
+    let suffix_len = common_suffix_len_all(&selected);
+    if suffix_len >= 2 && selected.iter().all(|segments| suffix_len < segments.len()) {
+        for segments in shortened.values_mut() {
+            segments.truncate(segments.len() - suffix_len);
+        }
+    }
+
+    Some(shortened)
+}
+
+fn split_upper_camel_case(name: &str) -> Vec<String> {
+    let chars = name.char_indices().collect::<Vec<_>>();
+    let mut segments = Vec::new();
+    let mut segment_start = 0;
+
+    for (index, &(byte_index, ch)) in chars.iter().enumerate().skip(1) {
+        let previous = chars[index - 1].1;
+        let next = chars.get(index + 1).map(|(_, ch)| *ch);
+        if ch.is_uppercase() && (!previous.is_uppercase() || next.is_some_and(char::is_lowercase)) {
+            segments.push(name[segment_start..byte_index].to_string());
+            segment_start = byte_index;
+        }
+    }
+
+    segments.push(name[segment_start..].to_string());
+    segments
+}
+
+fn common_prefix_len_all(items: &[&[String]]) -> usize {
+    let Some(first) = items.first() else {
+        return 0;
+    };
+
+    first
+        .iter()
+        .enumerate()
+        .take_while(|(index, segment)| items.iter().all(|item| item.get(*index) == Some(segment)))
+        .count()
+}
+
+fn common_suffix_len_all(items: &[&[String]]) -> usize {
+    let Some(first) = items.first() else {
+        return 0;
+    };
+
+    first
+        .iter()
+        .rev()
+        .enumerate()
+        .take_while(|(index, segment)| items.iter().all(|item| item.iter().rev().nth(*index) == Some(segment)))
+        .count()
+}
+
+fn is_base_variant_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Boolean" | "Decimal" | "DocumentUri" | "Integer" | "Null" | "String" | "UInteger" | "Uri"
+    )
 }
 
 fn unique_variant_name(names: &IndexSet<String>, name: String, index: usize) -> String {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -667,6 +667,7 @@ struct UnionVariant {
     name: String,
     original_name: Option<String>,
     ty: String,
+    proposed: bool,
 }
 
 impl UnionRegistry {
@@ -974,12 +975,17 @@ fn gen_union_def(union: &UnionDef) -> String {
         .variants
         .iter()
         .map(|variant| {
+            let cfg = if variant.proposed {
+                "    #[cfg(feature = \"proposed\")]\n"
+            } else {
+                ""
+            };
             let original_name = variant
                 .original_name
                 .as_ref()
                 .map(|name| format!("    /// `{name}`.\n"))
                 .unwrap_or_default();
-            format!("{original_name}    {}({}),", variant.name, variant.ty)
+            format!("{cfg}{original_name}    {}({}),", variant.name, variant.ty)
         })
         .join("\n");
     let from_impls = gen_union_from_impls(union);
@@ -1009,17 +1015,13 @@ fn gen_cfg(proposed: bool) -> &'static str {
     }
 }
 
-fn gen_union_cfg(union: &UnionDef) -> &'static str {
-    gen_cfg(union.proposed)
-}
-
 fn gen_union_from_impls(union: &UnionDef) -> String {
     union
         .variants
         .iter()
         .filter(|variant| variant.ty != union.name && has_unique_variant_type(union, &variant.ty))
         .map(|variant| {
-            let cfg = gen_union_cfg(union);
+            let cfg = gen_cfg(union.proposed || variant.proposed);
             format!(
                 "\n\n{cfg}impl From<{}> for {} {{\n    fn from(value: {}) -> Self {{\n        Self::{}(value)\n    }}\n}}",
                 variant.ty, union.name, variant.ty, variant.name
@@ -1053,7 +1055,7 @@ fn gen_type_def(
             gen_type_def(value, unions, &context.map_value(), proposed, None)
         ),
         TypeDef::Or { items } => {
-            let items = normalize_union_items(items);
+            let items = items.to_vec();
             if items.len() == 1 {
                 gen_type_def(items.first().unwrap(), unions, context, proposed, documentation)
             } else {
@@ -1071,6 +1073,7 @@ fn gen_type_def(
                             name: variant_name,
                             original_name,
                             ty,
+                            proposed: variant_requires_proposed_feature(item),
                         }
                     })
                     .collect();
@@ -1096,19 +1099,11 @@ fn gen_type_def(
 }
 
 fn is_multi_union(type_def: &TypeDef) -> bool {
-    matches!(type_def, TypeDef::Or { items } if normalize_union_items(items).len() > 1)
+    matches!(type_def, TypeDef::Or { items } if items.len() > 1)
 }
 
-fn normalize_union_items(items: &[TypeDef]) -> Vec<TypeDef> {
-    if items.len() == 3
-        && matches!(items.first(), Some(item) if is_ref(item, "TextEdit"))
-        && matches!(items.get(1), Some(item) if is_ref(item, "AnnotatedTextEdit"))
-        && matches!(items.get(2), Some(item) if is_ref(item, "SnippetTextEdit"))
-    {
-        items[..2].to_vec()
-    } else {
-        items.to_vec()
-    }
+fn variant_requires_proposed_feature(type_def: &TypeDef) -> bool {
+    is_ref(type_def, "SnippetTextEdit")
 }
 
 fn is_ref(type_def: &TypeDef, expected: &str) -> bool {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -835,6 +835,7 @@ fn gen_unions(unions: &UnionRegistry) -> String {
         .iter()
         .map(|union| {
             let doc = gen_doc(union.documentation.as_deref(), 0);
+            let cfg = gen_union_cfg(union);
             let variants = union
                 .variants
                 .iter()
@@ -847,13 +848,9 @@ fn gen_unions(unions: &UnionRegistry) -> String {
                     format!("{original_name}    {}({}),", variant.name, variant.ty)
                 })
                 .join("\n");
+            let from_impls = gen_union_from_impls(union);
             format!(
-                "{}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}",
-                if union.proposed {
-                    "#[cfg(feature = \"proposed\")]\n"
-                } else {
-                    ""
-                },
+                "{cfg}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}{from_impls}",
                 doc,
                 if doc.is_empty() { "" } else { "\n" },
                 union.name,
@@ -861,6 +858,33 @@ fn gen_unions(unions: &UnionRegistry) -> String {
             )
         })
         .join("\n\n")
+}
+
+fn gen_union_cfg(union: &UnionDef) -> &'static str {
+    if union.proposed {
+        "#[cfg(feature = \"proposed\")]\n"
+    } else {
+        ""
+    }
+}
+
+fn gen_union_from_impls(union: &UnionDef) -> String {
+    union
+        .variants
+        .iter()
+        .filter(|variant| variant.ty != union.name && has_unique_variant_type(union, &variant.ty))
+        .map(|variant| {
+            let cfg = gen_union_cfg(union);
+            format!(
+                "\n\n{cfg}impl From<{}> for {} {{\n    fn from(value: {}) -> Self {{\n        Self::{}(value)\n    }}\n}}",
+                variant.ty, union.name, variant.ty, variant.name
+            )
+        })
+        .join("")
+}
+
+fn has_unique_variant_type(union: &UnionDef, ty: &str) -> bool {
+    union.variants.iter().filter(|variant| variant.ty == ty).count() == 1
 }
 
 fn gen_type_def(

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -220,6 +220,7 @@ fn gen_requests(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
         } else {
             result_types.extend(request.partial_result.iter().cloned())
         }
+        let response_name = gen_request_response_name(&request.type_name);
         let result = if optional {
             format!(
                 "Option<{}>",
@@ -228,7 +229,7 @@ fn gen_requests(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
                         items: result_types.into_iter().collect()
                     },
                     unions,
-                    &format!("{}Result", request.type_name),
+                    &response_name,
                     request.proposed,
                     None,
                 )
@@ -241,7 +242,7 @@ fn gen_requests(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
                     items: result_types.into_iter().collect(),
                 },
                 unions,
-                &format!("{}Result", request.type_name),
+                &response_name,
                 request.proposed,
                 None,
             )
@@ -265,6 +266,10 @@ impl Request for {} {{
         );
         output
     })
+}
+
+fn gen_request_response_name(type_name: &str) -> String {
+    format!("{}Response", type_name.strip_suffix("Request").unwrap_or(type_name))
 }
 
 fn gen_notifications(lsp_def: &LspDef) -> String {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -785,19 +785,34 @@ struct ReusableUnionVariant {
     ty: &'static str,
 }
 
-const REUSABLE_UNIONS: &[ReusableUnion] = &[ReusableUnion {
-    name: "StringOrMarkupContent",
-    variants: &[
-        ReusableUnionVariant {
-            name: "String",
-            ty: "String",
-        },
-        ReusableUnionVariant {
-            name: "MarkupContent",
-            ty: "MarkupContent",
-        },
-    ],
-}];
+const REUSABLE_UNIONS: &[ReusableUnion] = &[
+    ReusableUnion {
+        name: "NumberOrString",
+        variants: &[
+            ReusableUnionVariant {
+                name: "Integer",
+                ty: "i32",
+            },
+            ReusableUnionVariant {
+                name: "String",
+                ty: "String",
+            },
+        ],
+    },
+    ReusableUnion {
+        name: "StringOrMarkupContent",
+        variants: &[
+            ReusableUnionVariant {
+                name: "String",
+                ty: "String",
+            },
+            ReusableUnionVariant {
+                name: "MarkupContent",
+                ty: "MarkupContent",
+            },
+        ],
+    },
+];
 
 fn reusable_union_name(variants: &[UnionVariant]) -> Option<&'static str> {
     REUSABLE_UNIONS

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -764,14 +764,7 @@ impl UnionRegistry {
             return name;
         }
 
-        for index in 2.. {
-            let candidate = format!("{name}{index}");
-            if self.names.insert(candidate.clone()) {
-                return candidate;
-            }
-        }
-
-        unreachable!()
+        panic!("duplicate generated union name `{name}`")
     }
 }
 
@@ -1180,7 +1173,7 @@ fn shorten_variant_names(type_defs: &[TypeDef], names: Vec<String>, enum_name: &
                     .and_then(|segments| segments.get(&index))
                     .map(|segments| segments.concat()),
             ];
-            let name = choose_variant_name(&shortened_names, &name, candidates.into_iter().flatten(), index);
+            let name = choose_variant_name(&shortened_names, &name, candidates.into_iter().flatten(), enum_name);
             shortened_names.insert(name);
             shortened_names
         })
@@ -1319,7 +1312,7 @@ fn choose_variant_name(
     names: &IndexSet<String>,
     original: &str,
     candidates: impl IntoIterator<Item = String>,
-    index: usize,
+    enum_name: &str,
 ) -> String {
     for candidate in candidates.into_iter().chain([original.to_string()]) {
         if !candidate.is_empty() && !names.contains(&candidate) {
@@ -1327,14 +1320,7 @@ fn choose_variant_name(
         }
     }
 
-    for suffix in 2.. {
-        let candidate = format!("{original}{suffix}");
-        if !names.contains(&candidate) {
-            return candidate;
-        }
-    }
-
-    format!("Variant{index}")
+    panic!("duplicate generated variant `{original}` in union `{enum_name}`")
 }
 
 fn gen_base_type(base_type: &BaseType) -> &'static str {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -677,10 +677,10 @@ impl UnionRegistry {
         proposed: bool,
     ) -> String {
         if let Some(target_name) = reusable_union_name(&variants) {
-            return self.push_reusable(name, target_name, variants, documentation, proposed);
+            self.push_reusable(name, target_name, variants, documentation, proposed)
+        } else {
+            self.push_definition(name, variants, documentation, proposed)
         }
-
-        self.push_definition(name, variants, documentation, proposed)
     }
 
     fn push_reusable(
@@ -691,7 +691,11 @@ impl UnionRegistry {
         documentation: Option<&str>,
         proposed: bool,
     ) -> String {
-        let target_documentation = (requested_name == target_name).then_some(documentation).flatten();
+        let target_documentation = if requested_name == target_name {
+            documentation
+        } else {
+            None
+        };
         let target = self.push_definition(target_name.into(), variants, target_documentation, proposed);
         if requested_name == target {
             target
@@ -945,10 +949,10 @@ fn shorten_field_union_name(parent: &str, field: &str) -> String {
         .or_else(|| parent.strip_suffix("Options"))
         && !stem.is_empty()
     {
-        return format!("{stem}{field}");
+        format!("{stem}{field}")
+    } else {
+        format!("{parent}{field}")
     }
-
-    format!("{parent}{field}")
 }
 
 fn gen_unions(unions: &UnionRegistry) -> String {
@@ -1103,10 +1107,10 @@ fn normalize_union_items(items: &[TypeDef]) -> Vec<TypeDef> {
         && matches!(items.get(1), Some(item) if is_ref(item, "AnnotatedTextEdit"))
         && matches!(items.get(2), Some(item) if is_ref(item, "SnippetTextEdit"))
     {
-        return items[..2].to_vec();
+        items[..2].to_vec()
+    } else {
+        items.to_vec()
     }
-
-    items.to_vec()
 }
 
 fn is_ref(type_def: &TypeDef, expected: &str) -> bool {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -890,7 +890,7 @@ fn gen_type_def(
             } else {
                 let union_name = context.union_name();
                 let original_variant_names = items.iter().map(gen_variant_name).collect::<Vec<_>>();
-                let variant_names = shorten_variant_names(original_variant_names.clone(), &union_name);
+                let variant_names = shorten_variant_names(&items, original_variant_names.clone(), &union_name);
                 let variants = items
                     .iter()
                     .zip(original_variant_names)
@@ -953,7 +953,7 @@ fn gen_variant_name(type_def: &TypeDef) -> String {
             BaseType::Uinteger => "UInteger",
             BaseType::Integer => "Integer",
             BaseType::String => "String",
-            BaseType::Boolean => "Boolean",
+            BaseType::Boolean => "Bool",
             BaseType::DocumentUri => "DocumentUri",
             BaseType::Uri => "Uri",
             BaseType::Decimal => "Decimal",
@@ -975,15 +975,17 @@ fn gen_variant_name(type_def: &TypeDef) -> String {
     }
 }
 
-fn shorten_variant_names(names: Vec<String>, enum_name: &str) -> Vec<String> {
+fn shorten_variant_names(type_defs: &[TypeDef], names: Vec<String>, enum_name: &str) -> Vec<String> {
+    debug_assert_eq!(type_defs.len(), names.len());
+
     let segments = names
         .iter()
         .map(|name| split_upper_camel_case(name))
         .collect::<Vec<_>>();
-    let named_variant_indices = names
+    let named_variant_indices = type_defs
         .iter()
         .enumerate()
-        .filter_map(|(index, name)| (!is_base_variant_name(name)).then_some(index))
+        .filter_map(|(index, type_def)| (!is_base_variant_type(type_def)).then_some(index))
         .collect::<Vec<_>>();
     let candidate_segments = shortened_variant_segments(&segments, &named_variant_indices);
     let enum_segments = split_upper_camel_case(enum_name);
@@ -992,8 +994,11 @@ fn shorten_variant_names(names: Vec<String>, enum_name: &str) -> Vec<String> {
         .into_iter()
         .enumerate()
         .fold(IndexSet::new(), |mut shortened_names, (index, name)| {
+            let is_base_variant = is_base_variant_type(&type_defs[index]);
             let candidates = [
-                shortened_variant_against_enum(&segments[index], &enum_segments, named_variant_indices.len()),
+                (!is_base_variant)
+                    .then(|| shortened_variant_against_enum(&segments[index], &enum_segments, named_variant_indices.len()))
+                    .flatten(),
                 candidate_segments
                     .as_ref()
                     .and_then(|segments| segments.get(&index))
@@ -1052,7 +1057,7 @@ fn shortened_variant_against_enum(
     enum_segments: &[String],
     named_variant_count: usize,
 ) -> Option<String> {
-    if named_variant_count != 1 || is_base_variant_name(&segments.concat()) {
+    if named_variant_count != 1 {
         return None;
     }
 
@@ -1112,11 +1117,8 @@ fn common_suffix_len_all(items: &[&[String]]) -> usize {
         .count()
 }
 
-fn is_base_variant_name(name: &str) -> bool {
-    matches!(
-        name,
-        "Boolean" | "Decimal" | "DocumentUri" | "Integer" | "Null" | "String" | "UInteger" | "Uri"
-    )
+fn is_base_variant_type(type_def: &TypeDef) -> bool {
+    matches!(type_def, TypeDef::Base { .. })
 }
 
 fn is_generic_variant_name(name: &str) -> bool {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -103,6 +103,7 @@ use serde::{{Deserialize, Deserializer, Serialize, Serializer}};
 use crate::{{HashMap, Uri}};
 use serde::{{Deserialize, Serialize}};
 use super::*;
+
 {}",
             unions,
         ),
@@ -983,11 +984,8 @@ fn gen_union_def(union: &UnionDef) -> String {
         .join("\n");
     let from_impls = gen_union_from_impls(union);
     format!(
-        "{cfg}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}{from_impls}",
-        doc,
-        if doc.is_empty() { "" } else { "\n" },
-        union.name,
-        variants,
+        "{cfg}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]{}\npub enum {} {{\n{}\n}}{from_impls}",
+        doc, union.name, variants,
     )
 }
 

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -754,12 +754,17 @@ impl UnionContext {
 
     fn union_name(&self) -> String {
         match self {
+            Self::ArrayItem(parent) if parent.is_notebook_selector_field() => "NotebookSelectorItem".into(),
             Self::StructField { parent, field } if should_shorten_server_capabilities_field(parent, field) => {
                 field.to_upper_camel_case()
             }
             Self::MapValue(parent) if parent.is_related_diagnostic_documents() => {
                 "RelatedDocumentDiagnosticReport".into()
             }
+            Self::StructField { parent, field } if is_notebook_filter_notebook_field(parent, field) => {
+                "NotebookDocumentFilterNotebook".into()
+            }
+            Self::StructField { parent, field } => shorten_field_union_name(parent, field),
             _ => self.fallback_name(),
         }
     }
@@ -789,10 +794,39 @@ impl UnionContext {
                     )
         )
     }
+
+    fn is_notebook_selector_field(&self) -> bool {
+        matches!(self, Self::StructField { field, .. } if field == "notebookSelector")
+    }
 }
 
 fn should_shorten_server_capabilities_field(parent: &str, field: &str) -> bool {
     parent == "ServerCapabilities" && (field.ends_with("Provider") || field.ends_with("Sync"))
+}
+
+fn is_notebook_filter_notebook_field(parent: &str, field: &str) -> bool {
+    field == "notebook"
+        && matches!(
+            parent,
+            "NotebookDocumentFilterWithNotebook"
+                | "NotebookDocumentFilterWithCells"
+                | "NotebookCellTextDocumentFilter"
+        )
+}
+
+fn shorten_field_union_name(parent: &str, field: &str) -> String {
+    let field = field.to_upper_camel_case();
+    if let Some(stem) = parent
+        .strip_suffix("RegistrationOptions")
+        .or_else(|| parent.strip_suffix("ClientCapabilities"))
+        .or_else(|| parent.strip_suffix("ServerCapabilities"))
+        .or_else(|| parent.strip_suffix("Options"))
+        && !stem.is_empty()
+    {
+        return format!("{stem}{field}");
+    }
+
+    format!("{parent}{field}")
 }
 
 fn gen_unions(unions: &UnionRegistry) -> String {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -636,6 +636,8 @@ impl<'de> Deserialize<'de> for {name} {{
 struct UnionRegistry {
     names: IndexSet<String>,
     definitions: Vec<UnionDef>,
+    aliases: Vec<UnionAlias>,
+    entries: Vec<UnionEntry>,
 }
 
 struct UnionDef {
@@ -644,6 +646,19 @@ struct UnionDef {
     variants: Vec<UnionVariant>,
     documentation: Option<String>,
     proposed: bool,
+}
+
+struct UnionAlias {
+    requested_name: String,
+    name: String,
+    target: String,
+    documentation: Option<String>,
+    proposed: bool,
+}
+
+enum UnionEntry {
+    Definition(usize),
+    Alias(usize),
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -661,6 +676,37 @@ impl UnionRegistry {
         documentation: Option<&str>,
         proposed: bool,
     ) -> String {
+        if let Some(target_name) = reusable_union_name(&variants) {
+            return self.push_reusable(name, target_name, variants, documentation, proposed);
+        }
+
+        self.push_definition(name, variants, documentation, proposed)
+    }
+
+    fn push_reusable(
+        &mut self,
+        requested_name: String,
+        target_name: &str,
+        variants: Vec<UnionVariant>,
+        documentation: Option<&str>,
+        proposed: bool,
+    ) -> String {
+        let target_documentation = (requested_name == target_name).then_some(documentation).flatten();
+        let target = self.push_definition(target_name.into(), variants, target_documentation, proposed);
+        if requested_name == target {
+            target
+        } else {
+            self.push_alias(requested_name, target, documentation, proposed)
+        }
+    }
+
+    fn push_definition(
+        &mut self,
+        name: String,
+        variants: Vec<UnionVariant>,
+        documentation: Option<&str>,
+        proposed: bool,
+    ) -> String {
         let requested_name = name;
         if let Some(definition) = self
             .definitions
@@ -672,6 +718,7 @@ impl UnionRegistry {
         }
 
         let name = self.unique_name(requested_name.clone());
+        let index = self.definitions.len();
         self.definitions.push(UnionDef {
             requested_name,
             name: name.clone(),
@@ -679,6 +726,36 @@ impl UnionRegistry {
             documentation: documentation.map(str::to_string),
             proposed,
         });
+        self.entries.push(UnionEntry::Definition(index));
+        name
+    }
+
+    fn push_alias(
+        &mut self,
+        requested_name: String,
+        target: String,
+        documentation: Option<&str>,
+        proposed: bool,
+    ) -> String {
+        if let Some(alias) = self
+            .aliases
+            .iter_mut()
+            .find(|alias| alias.requested_name == requested_name && alias.target == target)
+        {
+            alias.proposed &= proposed;
+            return alias.name.clone();
+        }
+
+        let name = self.unique_name(requested_name.clone());
+        let index = self.aliases.len();
+        self.aliases.push(UnionAlias {
+            requested_name,
+            name: name.clone(),
+            target,
+            documentation: documentation.map(str::to_string),
+            proposed,
+        });
+        self.entries.push(UnionEntry::Alias(index));
         name
     }
 
@@ -696,6 +773,45 @@ impl UnionRegistry {
 
         unreachable!()
     }
+}
+
+struct ReusableUnion {
+    name: &'static str,
+    variants: &'static [ReusableUnionVariant],
+}
+
+struct ReusableUnionVariant {
+    name: &'static str,
+    ty: &'static str,
+}
+
+const REUSABLE_UNIONS: &[ReusableUnion] = &[ReusableUnion {
+    name: "StringOrMarkupContent",
+    variants: &[
+        ReusableUnionVariant {
+            name: "String",
+            ty: "String",
+        },
+        ReusableUnionVariant {
+            name: "MarkupContent",
+            ty: "MarkupContent",
+        },
+    ],
+}];
+
+fn reusable_union_name(variants: &[UnionVariant]) -> Option<&'static str> {
+    REUSABLE_UNIONS
+        .iter()
+        .find(|reusable| {
+            variants.len() == reusable.variants.len()
+                && variants
+                    .iter()
+                    .zip(reusable.variants)
+                    .all(|(variant, reusable_variant)| {
+                        variant.name == reusable_variant.name && variant.ty == reusable_variant.ty
+                    })
+        })
+        .map(|reusable| reusable.name)
 }
 
 #[derive(Clone)]
@@ -808,9 +924,7 @@ fn is_notebook_filter_notebook_field(parent: &str, field: &str) -> bool {
     field == "notebook"
         && matches!(
             parent,
-            "NotebookDocumentFilterWithNotebook"
-                | "NotebookDocumentFilterWithCells"
-                | "NotebookCellTextDocumentFilter"
+            "NotebookDocumentFilterWithNotebook" | "NotebookDocumentFilterWithCells" | "NotebookCellTextDocumentFilter"
         )
 }
 
@@ -831,41 +945,62 @@ fn shorten_field_union_name(parent: &str, field: &str) -> String {
 
 fn gen_unions(unions: &UnionRegistry) -> String {
     unions
-        .definitions
+        .entries
         .iter()
-        .map(|union| {
-            let doc = gen_doc(union.documentation.as_deref(), 0);
-            let cfg = gen_union_cfg(union);
-            let variants = union
-                .variants
-                .iter()
-                .map(|variant| {
-                    let original_name = variant
-                        .original_name
-                        .as_ref()
-                        .map(|name| format!("    /// `{name}`.\n"))
-                        .unwrap_or_default();
-                    format!("{original_name}    {}({}),", variant.name, variant.ty)
-                })
-                .join("\n");
-            let from_impls = gen_union_from_impls(union);
-            format!(
-                "{cfg}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}{from_impls}",
-                doc,
-                if doc.is_empty() { "" } else { "\n" },
-                union.name,
-                variants,
-            )
+        .map(|entry| match entry {
+            UnionEntry::Definition(index) => gen_union_def(&unions.definitions[*index]),
+            UnionEntry::Alias(index) => gen_union_alias(&unions.aliases[*index]),
         })
         .join("\n\n")
 }
 
-fn gen_union_cfg(union: &UnionDef) -> &'static str {
-    if union.proposed {
+fn gen_union_def(union: &UnionDef) -> String {
+    let doc = gen_doc(union.documentation.as_deref(), 0);
+    let cfg = gen_cfg(union.proposed);
+    let variants = union
+        .variants
+        .iter()
+        .map(|variant| {
+            let original_name = variant
+                .original_name
+                .as_ref()
+                .map(|name| format!("    /// `{name}`.\n"))
+                .unwrap_or_default();
+            format!("{original_name}    {}({}),", variant.name, variant.ty)
+        })
+        .join("\n");
+    let from_impls = gen_union_from_impls(union);
+    format!(
+        "{cfg}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}{from_impls}",
+        doc,
+        if doc.is_empty() { "" } else { "\n" },
+        union.name,
+        variants,
+    )
+}
+
+fn gen_union_alias(alias: &UnionAlias) -> String {
+    let doc = gen_doc(alias.documentation.as_deref(), 0);
+    let cfg = gen_cfg(alias.proposed);
+    format!(
+        "{cfg}{}{}pub type {} = {};",
+        doc,
+        if doc.is_empty() { "" } else { "\n" },
+        alias.name,
+        alias.target
+    )
+}
+
+fn gen_cfg(proposed: bool) -> &'static str {
+    if proposed {
         "#[cfg(feature = \"proposed\")]\n"
     } else {
         ""
     }
+}
+
+fn gen_union_cfg(union: &UnionDef) -> &'static str {
+    gen_cfg(union.proposed)
 }
 
 fn gen_union_from_impls(union: &UnionDef) -> String {
@@ -1021,7 +1156,9 @@ fn shorten_variant_names(type_defs: &[TypeDef], names: Vec<String>, enum_name: &
             let is_base_variant = is_base_variant_type(&type_defs[index]);
             let candidates = [
                 (!is_base_variant)
-                    .then(|| shortened_variant_against_enum(&segments[index], &enum_segments, named_variant_indices.len()))
+                    .then(|| {
+                        shortened_variant_against_enum(&segments[index], &enum_segments, named_variant_indices.len())
+                    })
                     .flatten(),
                 candidate_segments
                     .as_ref()

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2,7 +2,16 @@ use heck::{ToSnakeCase, ToUpperCamelCase};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use serde::Deserialize;
-use std::{env, fmt::Write, fs};
+use std::{env, fmt::Write, fs, process::Command};
+
+const GENERATED_FILES: &[&str] = &[
+    "./lspt/src/generated/request.rs",
+    "./lspt/src/generated/notification.rs",
+    "./lspt/src/generated/structs.rs",
+    "./lspt/src/generated/enums.rs",
+    "./lspt/src/generated/unions.rs",
+    "./lspt/src/generated/type_aliases.rs",
+];
 
 fn main() -> anyhow::Result<()> {
     let agent = if let Ok(proxy) = env::var("https_proxy") {
@@ -15,13 +24,20 @@ fn main() -> anyhow::Result<()> {
         .get("https://raw.githubusercontent.com/microsoft/lsprotocol/refs/heads/main/generator/lsp.json")
         .call()?
         .into_json::<LspDef>()?;
+    let mut unions = UnionRegistry::default();
+
+    let type_aliases = gen_type_aliases(&lsp_def, &mut unions);
+    let requests = gen_requests(&lsp_def, &mut unions);
+    let notifications = gen_notifications(&lsp_def);
+    let structs = gen_structs(&lsp_def, &mut unions);
+    let enums = gen_enums(&lsp_def);
+    let unions = gen_unions(&unions);
 
     fs::write(
         "./lspt/src/generated/request.rs",
         format!(
             "// DO NOT EDIT THIS GENERATED FILE.
 
-use crate::{{Union2, Union3, Union4}};
 use serde::Serialize;
 use super::*;
 
@@ -33,7 +49,7 @@ pub trait Request {{
 {}
 {}",
             gen_request_macros(&lsp_def),
-            gen_requests(&lsp_def),
+            requests,
         ),
     )?;
 
@@ -52,7 +68,7 @@ pub trait Notification {{
 {}
 {}",
             gen_notification_macros(&lsp_def),
-            gen_notifications(&lsp_def),
+            notifications,
         ),
     )?;
 
@@ -61,11 +77,11 @@ pub trait Notification {{
         format!(
             "// DO NOT EDIT THIS GENERATED FILE.
 
-use crate::{{HashMap, Union2, Union3, Union4, Uri}};
+use crate::{{HashMap, Uri}};
 use serde::{{Deserialize, Serialize}};
 use super::*;
 {}",
-            gen_structs(&lsp_def),
+            structs,
         ),
     )?;
 
@@ -78,7 +94,26 @@ use serde::{{Deserialize, Deserializer, Serialize, Serializer}};
 
 {}
 ",
-            gen_enums(&lsp_def),
+            enums,
+        ),
+    )?;
+
+    fs::write(
+        "./lspt/src/generated/unions.rs",
+        format!(
+            "// DO NOT EDIT THIS GENERATED FILE.
+
+#![allow(deprecated)]
+#![allow(clippy::doc_lazy_continuation)]
+#![allow(clippy::large_enum_variant)]
+#![allow(rustdoc::invalid_codeblock_attributes)]
+#![allow(unused_imports)]
+
+use crate::{{HashMap, Uri}};
+use serde::{{Deserialize, Serialize}};
+use super::*;
+{}",
+            unions,
         ),
     )?;
 
@@ -88,12 +123,19 @@ use serde::{{Deserialize, Deserializer, Serialize, Serializer}};
             "// DO NOT EDIT THIS GENERATED FILE.
 
 use super::*;
-use crate::{{Union2, Union3}};
 {}",
-            gen_type_aliases(&lsp_def),
+            type_aliases,
         ),
     )?;
 
+    format_generated_files()?;
+
+    Ok(())
+}
+
+fn format_generated_files() -> anyhow::Result<()> {
+    let status = Command::new("rustfmt").args(GENERATED_FILES).status()?;
+    anyhow::ensure!(status.success(), "rustfmt failed to format generated files");
     Ok(())
 }
 
@@ -167,7 +209,7 @@ fn gen_method_macro_arms<'a>(methods: impl Iterator<Item = (&'a String, &'a Stri
         .join("")
 }
 
-fn gen_requests(lsp_def: &LspDef) -> String {
+fn gen_requests(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
     lsp_def.requests.iter().fold(String::new(), |mut output, request| {
         if request.proposed {
             output.push_str("\n#[cfg(feature = \"proposed\")]");
@@ -198,16 +240,28 @@ fn gen_requests(lsp_def: &LspDef) -> String {
         let result = if optional {
             format!(
                 "Option<{}>",
-                gen_type_def(&TypeDef::Or {
-                    items: result_types.into_iter().collect()
-                })
+                gen_type_def(
+                    &TypeDef::Or {
+                        items: result_types.into_iter().collect()
+                    },
+                    unions,
+                    &format!("{}Result", request.type_name),
+                    request.proposed,
+                    None,
+                )
             )
         } else if matches!(request.result, Some(TypeDef::Base { name: BaseType::Null }) | None) {
             "()".into()
         } else {
-            gen_type_def(&TypeDef::Or {
-                items: result_types.into_iter().collect(),
-            })
+            gen_type_def(
+                &TypeDef::Or {
+                    items: result_types.into_iter().collect(),
+                },
+                unions,
+                &format!("{}Result", request.type_name),
+                request.proposed,
+                None,
+            )
         };
         let _ = write!(
             output,
@@ -262,7 +316,7 @@ impl Notification for {} {{
         })
 }
 
-fn gen_structs(lsp_def: &LspDef) -> String {
+fn gen_structs(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
     lsp_def
         .structures
         .iter()
@@ -305,7 +359,7 @@ fn gen_structs(lsp_def: &LspDef) -> String {
                 .iter()
                 .chain(structure.properties.iter())
                 .chain(get_mixins(structure, lsp_def).iter())
-                .filter(|property| !property.deprecated.is_some())
+                .filter(|property| property.deprecated.is_none())
                 .fold(&mut output, |output, property| {
                     if property.proposed {
                         output.push_str("\n    #[cfg(feature = \"proposed\")]");
@@ -332,7 +386,13 @@ fn gen_structs(lsp_def: &LspDef) -> String {
                     } else {
                         property.ty.clone()
                     };
-                    let mut ty = gen_type_def(&type_def);
+                    let mut ty = gen_type_def(
+                        &type_def,
+                        unions,
+                        &format!("{}{}", structure.name, property.name.to_upper_camel_case()),
+                        structure.proposed || property.proposed,
+                        None,
+                    );
                     match &type_def {
                         TypeDef::Ref(TypeRef { name }) if name == &structure.name => {
                             ty = format!("Box<{ty}>");
@@ -353,10 +413,6 @@ fn gen_structs(lsp_def: &LspDef) -> String {
             output.push_str("}\n");
             output
         })
-        .replace(
-            "Vec<Union3<TextEdit, AnnotatedTextEdit, SnippetTextEdit>>",
-            "Vec<Union2<TextEdit, AnnotatedTextEdit>>",
-        ) // hard-coded workaround
 }
 fn can_derive_default(structure: &Structure, lsp_def: &LspDef) -> bool {
     !structure
@@ -423,20 +479,24 @@ fn get_mixins(structure: &Structure, lsp_def: &LspDef) -> Vec<Property> {
         })
 }
 
-fn gen_type_aliases(lsp_def: &LspDef) -> String {
+fn gen_type_aliases(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
     lsp_def
         .type_aliases
         .iter()
         .filter(|type_alias| !type_alias.name.starts_with("LSP"))
         .fold(String::new(), |mut output, type_alias| {
-            output.push_str(&gen_doc(type_alias.documentation.as_deref(), 0));
-            let _ = write!(
-                output,
-                "\npub type {} = {};",
-                type_alias.name,
-                gen_type_def(&type_alias.ty)
+            let ty = gen_type_def(
+                &type_alias.ty,
+                unions,
+                &type_alias.name,
+                false,
+                type_alias.documentation.as_deref(),
             );
-            output.push('\n');
+            if !is_multi_union(&type_alias.ty) {
+                output.push_str(&gen_doc(type_alias.documentation.as_deref(), 0));
+                let _ = write!(output, "\npub type {} = {ty};", type_alias.name);
+                output.push('\n');
+            }
             output
         })
 }
@@ -584,7 +644,92 @@ impl<'de> Deserialize<'de> for {name} {{
         .join("\n\n")
 }
 
-fn gen_type_def(type_def: &TypeDef) -> String {
+#[derive(Default)]
+struct UnionRegistry {
+    names: IndexSet<String>,
+    definitions: Vec<UnionDef>,
+}
+
+struct UnionDef {
+    name: String,
+    variants: Vec<UnionVariant>,
+    documentation: Option<String>,
+    proposed: bool,
+}
+
+struct UnionVariant {
+    name: String,
+    ty: String,
+}
+
+impl UnionRegistry {
+    fn push(
+        &mut self,
+        name: String,
+        variants: Vec<UnionVariant>,
+        documentation: Option<&str>,
+        proposed: bool,
+    ) -> String {
+        let name = self.unique_name(name);
+        self.definitions.push(UnionDef {
+            name: name.clone(),
+            variants,
+            documentation: documentation.map(str::to_string),
+            proposed,
+        });
+        name
+    }
+
+    fn unique_name(&mut self, name: String) -> String {
+        if self.names.insert(name.clone()) {
+            return name;
+        }
+
+        for index in 2.. {
+            let candidate = format!("{name}{index}");
+            if self.names.insert(candidate.clone()) {
+                return candidate;
+            }
+        }
+
+        unreachable!()
+    }
+}
+
+fn gen_unions(unions: &UnionRegistry) -> String {
+    unions
+        .definitions
+        .iter()
+        .map(|union| {
+            let doc = gen_doc(union.documentation.as_deref(), 0);
+            let variants = union
+                .variants
+                .iter()
+                .map(|variant| format!("    {}({}),", variant.name, variant.ty))
+                .join("\n");
+            format!(
+                "{}{}{}#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]\n#[serde(untagged)]\npub enum {} {{\n{}\n}}",
+                if union.proposed {
+                    "#[cfg(feature = \"proposed\")]\n"
+                } else {
+                    ""
+                },
+                doc,
+                if doc.is_empty() { "" } else { "\n" },
+                union.name,
+                variants,
+            )
+        })
+        .join("\n\n")
+}
+
+fn gen_type_def(
+    type_def: &TypeDef,
+    unions: &mut UnionRegistry,
+    name_hint: &str,
+    proposed: bool,
+    documentation: Option<&str>,
+) -> String {
     match type_def {
         TypeDef::Base { name } => gen_base_type(name).into(),
         TypeDef::Ref(TypeRef { name }) => match &**name {
@@ -593,20 +738,118 @@ fn gen_type_def(type_def: &TypeDef) -> String {
             name => name,
         }
         .into(),
-        TypeDef::Map { key, value } => format!("HashMap<{}, {}>", gen_type_def(key), gen_type_def(value)),
+        TypeDef::Map { key, value } => format!(
+            "HashMap<{}, {}>",
+            gen_type_def(key, unions, &format!("{name_hint}Key"), proposed, None),
+            gen_type_def(value, unions, &format!("{name_hint}Value"), proposed, None)
+        ),
         TypeDef::Or { items } => {
+            let items = normalize_union_items(items);
             if items.len() == 1 {
-                gen_type_def(items.first().unwrap())
+                gen_type_def(items.first().unwrap(), unions, name_hint, proposed, documentation)
             } else {
-                format!("Union{}<{}>", items.len(), items.iter().map(gen_type_def).join(", "))
+                let variant_names = items
+                    .iter()
+                    .map(gen_variant_name)
+                    .enumerate()
+                    .fold(IndexSet::new(), |mut names, (index, name)| {
+                        let name = unique_variant_name(&names, name, index);
+                        names.insert(name);
+                        names
+                    })
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                let variants = items
+                    .iter()
+                    .zip(variant_names)
+                    .map(|(item, variant_name)| {
+                        let ty = gen_type_def(item, unions, &format!("{name_hint}{variant_name}"), proposed, None);
+                        UnionVariant { name: variant_name, ty }
+                    })
+                    .collect();
+                unions.push(name_hint.to_upper_camel_case(), variants, documentation, proposed)
             }
         }
-        TypeDef::Array { element } => format!("Vec<{}>", gen_type_def(element)),
-        TypeDef::Tuple { items } => format!("({})", items.iter().map(gen_type_def).join(", ")),
+        TypeDef::Array { element } => format!(
+            "Vec<{}>",
+            gen_type_def(element, unions, &format!("{name_hint}Item"), proposed, None)
+        ),
+        TypeDef::Tuple { items } => format!(
+            "({})",
+            items
+                .iter()
+                .enumerate()
+                .map(|(index, item)| gen_type_def(item, unions, &format!("{name_hint}Item{index}"), proposed, None))
+                .join(", ")
+        ),
         TypeDef::Literal => "serde_json::Value".into(),
-        TypeDef::StringLiteral { .. } => "String".into(),
+        TypeDef::StringLiteral => "String".into(),
         _ => unreachable!(),
     }
+}
+
+fn is_multi_union(type_def: &TypeDef) -> bool {
+    matches!(type_def, TypeDef::Or { items } if normalize_union_items(items).len() > 1)
+}
+
+fn normalize_union_items(items: &[TypeDef]) -> Vec<TypeDef> {
+    if items.len() == 3
+        && matches!(items.first(), Some(item) if is_ref(item, "TextEdit"))
+        && matches!(items.get(1), Some(item) if is_ref(item, "AnnotatedTextEdit"))
+        && matches!(items.get(2), Some(item) if is_ref(item, "SnippetTextEdit"))
+    {
+        return items[..2].to_vec();
+    }
+
+    items.to_vec()
+}
+
+fn is_ref(type_def: &TypeDef, expected: &str) -> bool {
+    matches!(type_def, TypeDef::Ref(TypeRef { name }) if name == expected)
+}
+
+fn gen_variant_name(type_def: &TypeDef) -> String {
+    match type_def {
+        TypeDef::Base { name } => match name {
+            BaseType::Null => "Null",
+            BaseType::Uinteger => "UInteger",
+            BaseType::Integer => "Integer",
+            BaseType::String => "String",
+            BaseType::Boolean => "Boolean",
+            BaseType::DocumentUri => "DocumentUri",
+            BaseType::Uri => "Uri",
+            BaseType::Decimal => "Decimal",
+        }
+        .into(),
+        TypeDef::Ref(TypeRef { name }) => match &**name {
+            "LSPAny" => "Value",
+            "LSPObject" => "Object",
+            name => name,
+        }
+        .to_upper_camel_case(),
+        TypeDef::Map { value, .. } => format!("{}Map", gen_variant_name(value)),
+        TypeDef::Or { .. } => "Union".into(),
+        TypeDef::Array { element } => format!("{}List", gen_variant_name(element)),
+        TypeDef::Tuple { .. } => "Tuple".into(),
+        TypeDef::Literal => "Object".into(),
+        TypeDef::StringLiteral => "String".into(),
+        _ => unreachable!(),
+    }
+}
+
+fn unique_variant_name(names: &IndexSet<String>, name: String, index: usize) -> String {
+    if !names.contains(&name) {
+        return name;
+    }
+
+    for suffix in 2.. {
+        let candidate = format!("{name}{suffix}");
+        if !names.contains(&candidate) {
+            return candidate;
+        }
+    }
+
+    format!("Variant{index}")
 }
 
 fn gen_base_type(base_type: &BaseType) -> &'static str {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -201,52 +201,7 @@ fn gen_requests(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
         if request.proposed {
             output.push_str("\n#[cfg(feature = \"proposed\")]");
         }
-        let mut optional = false;
-        let mut result_types = if let Some(TypeDef::Or { items }) = &request.result {
-            let filtered_items = items
-                .iter()
-                .filter(|item| !matches!(item, TypeDef::Base { name: BaseType::Null }))
-                .cloned()
-                .collect::<IndexSet<_>>();
-            if filtered_items.len() != items.len() {
-                optional = true;
-            }
-            filtered_items
-        } else {
-            request.result.iter().cloned().collect()
-        };
-        if let Some(TypeDef::Or { items }) = &request.partial_result {
-            result_types.extend(items.iter().cloned());
-        } else {
-            result_types.extend(request.partial_result.iter().cloned())
-        }
-        let response_name = gen_request_response_name(&request.type_name);
-        let result = if optional {
-            format!(
-                "Option<{}>",
-                gen_type_def(
-                    &TypeDef::Or {
-                        items: result_types.into_iter().collect()
-                    },
-                    unions,
-                    &response_name,
-                    request.proposed,
-                    None,
-                )
-            )
-        } else if matches!(request.result, Some(TypeDef::Base { name: BaseType::Null }) | None) {
-            "()".into()
-        } else {
-            gen_type_def(
-                &TypeDef::Or {
-                    items: result_types.into_iter().collect(),
-                },
-                unions,
-                &response_name,
-                request.proposed,
-                None,
-            )
-        };
+        let result = gen_request_result(request, unions);
         let _ = write!(
             output,
             "
@@ -266,6 +221,51 @@ impl Request for {} {{
         );
         output
     })
+}
+
+fn gen_request_result(request: &Request, unions: &mut UnionRegistry) -> String {
+    let mut optional = false;
+    let mut result_types = IndexSet::new();
+    if let Some(result) = &request.result {
+        extend_result_types(result, &mut result_types, &mut optional);
+    }
+    if let Some(partial_result) = &request.partial_result {
+        extend_result_types(partial_result, &mut result_types, &mut optional);
+    }
+
+    if result_types.is_empty() {
+        return "()".into();
+    }
+
+    let response_name = gen_request_response_name(&request.type_name);
+    let result = gen_type_def(
+        &TypeDef::Or {
+            items: result_types.into_iter().collect(),
+        },
+        unions,
+        &UnionContext::request_response(&response_name),
+        request.proposed,
+        None,
+    );
+    if optional { format!("Option<{result}>") } else { result }
+}
+
+fn extend_result_types(type_def: &TypeDef, result_types: &mut IndexSet<TypeDef>, optional: &mut bool) {
+    match type_def {
+        TypeDef::Or { items } => {
+            for item in items {
+                if matches!(item, TypeDef::Base { name: BaseType::Null }) {
+                    *optional = true;
+                } else {
+                    result_types.insert(item.clone());
+                }
+            }
+        }
+        TypeDef::Base { name: BaseType::Null } => {}
+        type_def => {
+            result_types.insert(type_def.clone());
+        }
+    }
 }
 
 fn gen_request_response_name(type_name: &str) -> String {
@@ -377,7 +377,7 @@ fn gen_structs(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
                     let mut ty = gen_type_def(
                         &type_def,
                         unions,
-                        &format!("{}{}", structure.name, property.name.to_upper_camel_case()),
+                        &UnionContext::struct_field(&structure.name, &property.name),
                         structure.proposed || property.proposed,
                         None,
                     );
@@ -476,7 +476,7 @@ fn gen_type_aliases(lsp_def: &LspDef, unions: &mut UnionRegistry) -> String {
             let ty = gen_type_def(
                 &type_alias.ty,
                 unions,
-                &type_alias.name,
+                &UnionContext::type_alias(&type_alias.name),
                 false,
                 type_alias.documentation.as_deref(),
             );
@@ -639,12 +639,14 @@ struct UnionRegistry {
 }
 
 struct UnionDef {
+    requested_name: String,
     name: String,
     variants: Vec<UnionVariant>,
     documentation: Option<String>,
     proposed: bool,
 }
 
+#[derive(Clone, PartialEq, Eq)]
 struct UnionVariant {
     name: String,
     original_name: Option<String>,
@@ -659,8 +661,19 @@ impl UnionRegistry {
         documentation: Option<&str>,
         proposed: bool,
     ) -> String {
-        let name = self.unique_name(name);
+        let requested_name = name;
+        if let Some(definition) = self
+            .definitions
+            .iter_mut()
+            .find(|definition| definition.requested_name == requested_name && definition.variants == variants)
+        {
+            definition.proposed &= proposed;
+            return definition.name.clone();
+        }
+
+        let name = self.unique_name(requested_name.clone());
         self.definitions.push(UnionDef {
+            requested_name,
             name: name.clone(),
             variants,
             documentation: documentation.map(str::to_string),
@@ -683,6 +696,103 @@ impl UnionRegistry {
 
         unreachable!()
     }
+}
+
+#[derive(Clone)]
+enum UnionContext {
+    TypeAlias(String),
+    RequestResponse(String),
+    StructField { parent: String, field: String },
+    MapKey(Box<UnionContext>),
+    MapValue(Box<UnionContext>),
+    ArrayItem(Box<UnionContext>),
+    TupleItem { parent: Box<UnionContext>, index: usize },
+    Variant { parent: Box<UnionContext>, name: String },
+}
+
+impl UnionContext {
+    fn type_alias(name: &str) -> Self {
+        Self::TypeAlias(name.into())
+    }
+
+    fn request_response(name: &str) -> Self {
+        Self::RequestResponse(name.into())
+    }
+
+    fn struct_field(parent: &str, field: &str) -> Self {
+        Self::StructField {
+            parent: parent.into(),
+            field: field.into(),
+        }
+    }
+
+    fn map_key(&self) -> Self {
+        Self::MapKey(Box::new(self.clone()))
+    }
+
+    fn map_value(&self) -> Self {
+        Self::MapValue(Box::new(self.clone()))
+    }
+
+    fn array_item(&self) -> Self {
+        Self::ArrayItem(Box::new(self.clone()))
+    }
+
+    fn tuple_item(&self, index: usize) -> Self {
+        Self::TupleItem {
+            parent: Box::new(self.clone()),
+            index,
+        }
+    }
+
+    fn variant(&self, name: &str) -> Self {
+        Self::Variant {
+            parent: Box::new(self.clone()),
+            name: name.into(),
+        }
+    }
+
+    fn union_name(&self) -> String {
+        match self {
+            Self::StructField { parent, field } if should_shorten_server_capabilities_field(parent, field) => {
+                field.to_upper_camel_case()
+            }
+            Self::MapValue(parent) if parent.is_related_diagnostic_documents() => {
+                "RelatedDocumentDiagnosticReport".into()
+            }
+            _ => self.fallback_name(),
+        }
+    }
+
+    fn fallback_name(&self) -> String {
+        match self {
+            Self::TypeAlias(name) | Self::RequestResponse(name) => name.to_upper_camel_case(),
+            Self::StructField { parent, field } => format!("{}{}", parent, field.to_upper_camel_case()),
+            Self::MapKey(parent) => format!("{}Key", parent.union_name()),
+            Self::MapValue(parent) => format!("{}Value", parent.union_name()),
+            Self::ArrayItem(parent) => format!("{}Item", parent.union_name()),
+            Self::TupleItem { parent, index } => format!("{}Item{index}", parent.union_name()),
+            Self::Variant { parent, name } => format!("{}{}", parent.union_name(), name),
+        }
+    }
+
+    fn is_related_diagnostic_documents(&self) -> bool {
+        matches!(
+            self,
+            Self::StructField { parent, field }
+                if field == "relatedDocuments"
+                    && matches!(
+                        parent.as_str(),
+                        "DocumentDiagnosticReportPartialResult"
+                            | "RelatedFullDocumentDiagnosticReport"
+                            | "RelatedUnchangedDocumentDiagnosticReport"
+                    )
+        )
+    }
+}
+
+fn should_shorten_server_capabilities_field(parent: &str, field: &str) -> bool {
+    parent == "ServerCapabilities" && (field.ends_with("Provider") || field.ends_with("Sync"))
 }
 
 fn gen_unions(unions: &UnionRegistry) -> String {
@@ -722,7 +832,7 @@ fn gen_unions(unions: &UnionRegistry) -> String {
 fn gen_type_def(
     type_def: &TypeDef,
     unions: &mut UnionRegistry,
-    name_hint: &str,
+    context: &UnionContext,
     proposed: bool,
     documentation: Option<&str>,
 ) -> String {
@@ -736,22 +846,23 @@ fn gen_type_def(
         .into(),
         TypeDef::Map { key, value } => format!(
             "HashMap<{}, {}>",
-            gen_type_def(key, unions, &format!("{name_hint}Key"), proposed, None),
-            gen_type_def(value, unions, &format!("{name_hint}Value"), proposed, None)
+            gen_type_def(key, unions, &context.map_key(), proposed, None),
+            gen_type_def(value, unions, &context.map_value(), proposed, None)
         ),
         TypeDef::Or { items } => {
             let items = normalize_union_items(items);
             if items.len() == 1 {
-                gen_type_def(items.first().unwrap(), unions, name_hint, proposed, documentation)
+                gen_type_def(items.first().unwrap(), unions, context, proposed, documentation)
             } else {
+                let union_name = context.union_name();
                 let original_variant_names = items.iter().map(gen_variant_name).collect::<Vec<_>>();
-                let variant_names = shorten_variant_names(original_variant_names.clone());
+                let variant_names = shorten_variant_names(original_variant_names.clone(), &union_name);
                 let variants = items
                     .iter()
                     .zip(original_variant_names)
                     .zip(variant_names)
                     .map(|((item, original_name), variant_name)| {
-                        let ty = gen_type_def(item, unions, &format!("{name_hint}{variant_name}"), proposed, None);
+                        let ty = gen_type_def(item, unions, &context.variant(&original_name), proposed, None);
                         let original_name = (original_name != variant_name).then_some(original_name);
                         UnionVariant {
                             name: variant_name,
@@ -760,19 +871,19 @@ fn gen_type_def(
                         }
                     })
                     .collect();
-                unions.push(name_hint.to_upper_camel_case(), variants, documentation, proposed)
+                unions.push(union_name, variants, documentation, proposed)
             }
         }
         TypeDef::Array { element } => format!(
             "Vec<{}>",
-            gen_type_def(element, unions, &format!("{name_hint}Item"), proposed, None)
+            gen_type_def(element, unions, &context.array_item(), proposed, None)
         ),
         TypeDef::Tuple { items } => format!(
             "({})",
             items
                 .iter()
                 .enumerate()
-                .map(|(index, item)| gen_type_def(item, unions, &format!("{name_hint}Item{index}"), proposed, None))
+                .map(|(index, item)| gen_type_def(item, unions, &context.tuple_item(index), proposed, None))
                 .join(", ")
         ),
         TypeDef::Literal => "serde_json::Value".into(),
@@ -830,7 +941,7 @@ fn gen_variant_name(type_def: &TypeDef) -> String {
     }
 }
 
-fn shorten_variant_names(names: Vec<String>) -> Vec<String> {
+fn shorten_variant_names(names: Vec<String>, enum_name: &str) -> Vec<String> {
     let segments = names
         .iter()
         .map(|name| split_upper_camel_case(name))
@@ -841,17 +952,20 @@ fn shorten_variant_names(names: Vec<String>) -> Vec<String> {
         .filter_map(|(index, name)| (!is_base_variant_name(name)).then_some(index))
         .collect::<Vec<_>>();
     let candidate_segments = shortened_variant_segments(&segments, &named_variant_indices);
+    let enum_segments = split_upper_camel_case(enum_name);
 
     names
         .into_iter()
         .enumerate()
         .fold(IndexSet::new(), |mut shortened_names, (index, name)| {
-            let candidate = candidate_segments
-                .as_ref()
-                .and_then(|segments| segments.get(&index))
-                .map(|segments| segments.concat())
-                .unwrap_or(name);
-            let name = unique_variant_name(&shortened_names, candidate, index);
+            let candidates = [
+                shortened_variant_against_enum(&segments[index], &enum_segments, named_variant_indices.len()),
+                candidate_segments
+                    .as_ref()
+                    .and_then(|segments| segments.get(&index))
+                    .map(|segments| segments.concat()),
+            ];
+            let name = choose_variant_name(&shortened_names, &name, candidates.into_iter().flatten(), index);
             shortened_names.insert(name);
             shortened_names
         })
@@ -872,13 +986,17 @@ fn shortened_variant_segments(
         .map(|index| segments[*index].as_slice())
         .collect::<Vec<_>>();
     let prefix_len = common_prefix_len_all(&selected);
-    if prefix_len == 0 || selected.iter().any(|segments| prefix_len >= segments.len()) {
-        return None;
-    }
-
     let mut shortened = indices
         .iter()
-        .map(|index| (*index, segments[*index][prefix_len..].to_vec()))
+        .map(|index| {
+            let segments = &segments[*index];
+            let start = if prefix_len > 0 && prefix_len < segments.len() {
+                prefix_len
+            } else {
+                0
+            };
+            (*index, segments[start..].to_vec())
+        })
         .collect::<std::collections::HashMap<_, _>>();
 
     let selected = shortened.values().map(Vec::as_slice).collect::<Vec<_>>();
@@ -889,7 +1007,28 @@ fn shortened_variant_segments(
         }
     }
 
-    Some(shortened)
+    shortened
+        .iter()
+        .any(|(index, shortened_segments)| shortened_segments.as_slice() != segments[*index].as_slice())
+        .then_some(shortened)
+}
+
+fn shortened_variant_against_enum(
+    segments: &[String],
+    enum_segments: &[String],
+    named_variant_count: usize,
+) -> Option<String> {
+    if named_variant_count != 1 || is_base_variant_name(&segments.concat()) {
+        return None;
+    }
+
+    let prefix_len = common_prefix_len(segments, enum_segments);
+    if prefix_len == 0 || prefix_len >= segments.len() {
+        return None;
+    }
+
+    let candidate = segments[prefix_len..].concat();
+    (!is_generic_variant_name(&candidate)).then_some(candidate)
 }
 
 fn split_upper_camel_case(name: &str) -> Vec<String> {
@@ -922,6 +1061,10 @@ fn common_prefix_len_all(items: &[&[String]]) -> usize {
         .count()
 }
 
+fn common_prefix_len(left: &[String], right: &[String]) -> usize {
+    left.iter().zip(right).take_while(|(left, right)| left == right).count()
+}
+
 fn common_suffix_len_all(items: &[&[String]]) -> usize {
     let Some(first) = items.first() else {
         return 0;
@@ -942,13 +1085,38 @@ fn is_base_variant_name(name: &str) -> bool {
     )
 }
 
-fn unique_variant_name(names: &IndexSet<String>, name: String, index: usize) -> String {
-    if !names.contains(&name) {
-        return name;
+fn is_generic_variant_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Full"
+            | "Id"
+            | "Item"
+            | "Items"
+            | "Kind"
+            | "Label"
+            | "Object"
+            | "Params"
+            | "Range"
+            | "Result"
+            | "Tooltip"
+            | "Value"
+    )
+}
+
+fn choose_variant_name(
+    names: &IndexSet<String>,
+    original: &str,
+    candidates: impl IntoIterator<Item = String>,
+    index: usize,
+) -> String {
+    for candidate in candidates.into_iter().chain([original.to_string()]) {
+        if !candidate.is_empty() && !names.contains(&candidate) {
+            return candidate;
+        }
     }
 
     for suffix in 2.. {
-        let candidate = format!("{name}{suffix}");
+        let candidate = format!("{original}{suffix}");
         if !names.contains(&candidate) {
             return candidate;
         }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -2,16 +2,7 @@ use heck::{ToSnakeCase, ToUpperCamelCase};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use serde::Deserialize;
-use std::{env, fmt::Write, fs, process::Command};
-
-const GENERATED_FILES: &[&str] = &[
-    "./lspt/src/generated/request.rs",
-    "./lspt/src/generated/notification.rs",
-    "./lspt/src/generated/structs.rs",
-    "./lspt/src/generated/enums.rs",
-    "./lspt/src/generated/unions.rs",
-    "./lspt/src/generated/type_aliases.rs",
-];
+use std::{env, fmt::Write, fs};
 
 fn main() -> anyhow::Result<()> {
     let agent = if let Ok(proxy) = env::var("https_proxy") {
@@ -128,14 +119,6 @@ use super::*;
         ),
     )?;
 
-    format_generated_files()?;
-
-    Ok(())
-}
-
-fn format_generated_files() -> anyhow::Result<()> {
-    let status = Command::new("rustfmt").args(GENERATED_FILES).status()?;
-    anyhow::ensure!(status.success(), "rustfmt failed to format generated files");
     Ok(())
 }
 

--- a/lspt/src/generated/mod.rs
+++ b/lspt/src/generated/mod.rs
@@ -1,7 +1,8 @@
-pub use self::{enums::*, structs::*, type_aliases::*};
+pub use self::{enums::*, structs::*, type_aliases::*, unions::*};
 
 mod enums;
 pub mod notification;
 pub mod request;
 mod structs;
 mod type_aliases;
+mod unions;

--- a/lspt/src/generated/notification.rs
+++ b/lspt/src/generated/notification.rs
@@ -1,7 +1,7 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
-use serde::Serialize;
 use super::*;
+use serde::Serialize;
 
 pub trait Notification {
     const METHOD: &'static str;
@@ -11,65 +11,168 @@ pub trait Notification {
 #[cfg(all(feature = "macros", not(feature = "proposed")))]
 #[macro_export]
 macro_rules! lsp_notification {
-    ("workspace/didChangeWorkspaceFolders") => { $crate::notification::DidChangeWorkspaceFoldersNotification };
-    ("window/workDoneProgress/cancel") => { $crate::notification::WorkDoneProgressCancelNotification };
-    ("workspace/didCreateFiles") => { $crate::notification::DidCreateFilesNotification };
-    ("workspace/didRenameFiles") => { $crate::notification::DidRenameFilesNotification };
-    ("workspace/didDeleteFiles") => { $crate::notification::DidDeleteFilesNotification };
-    ("notebookDocument/didOpen") => { $crate::notification::DidOpenNotebookDocumentNotification };
-    ("notebookDocument/didChange") => { $crate::notification::DidChangeNotebookDocumentNotification };
-    ("notebookDocument/didSave") => { $crate::notification::DidSaveNotebookDocumentNotification };
-    ("notebookDocument/didClose") => { $crate::notification::DidCloseNotebookDocumentNotification };
-    ("initialized") => { $crate::notification::InitializedNotification };
-    ("exit") => { $crate::notification::ExitNotification };
-    ("workspace/didChangeConfiguration") => { $crate::notification::DidChangeConfigurationNotification };
-    ("window/showMessage") => { $crate::notification::ShowMessageNotification };
-    ("window/logMessage") => { $crate::notification::LogMessageNotification };
-    ("telemetry/event") => { $crate::notification::TelemetryEventNotification };
-    ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocumentNotification };
-    ("textDocument/didChange") => { $crate::notification::DidChangeTextDocumentNotification };
-    ("textDocument/didClose") => { $crate::notification::DidCloseTextDocumentNotification };
-    ("textDocument/didSave") => { $crate::notification::DidSaveTextDocumentNotification };
-    ("textDocument/willSave") => { $crate::notification::WillSaveTextDocumentNotification };
-    ("workspace/didChangeWatchedFiles") => { $crate::notification::DidChangeWatchedFilesNotification };
-    ("textDocument/publishDiagnostics") => { $crate::notification::PublishDiagnosticsNotification };
-    ("$/setTrace") => { $crate::notification::SetTraceNotification };
-    ("$/logTrace") => { $crate::notification::LogTraceNotification };
-    ("$/cancelRequest") => { $crate::notification::CancelNotification };
-    ("$/progress") => { $crate::notification::ProgressNotification };
+    ("workspace/didChangeWorkspaceFolders") => {
+        $crate::notification::DidChangeWorkspaceFoldersNotification
+    };
+    ("window/workDoneProgress/cancel") => {
+        $crate::notification::WorkDoneProgressCancelNotification
+    };
+    ("workspace/didCreateFiles") => {
+        $crate::notification::DidCreateFilesNotification
+    };
+    ("workspace/didRenameFiles") => {
+        $crate::notification::DidRenameFilesNotification
+    };
+    ("workspace/didDeleteFiles") => {
+        $crate::notification::DidDeleteFilesNotification
+    };
+    ("notebookDocument/didOpen") => {
+        $crate::notification::DidOpenNotebookDocumentNotification
+    };
+    ("notebookDocument/didChange") => {
+        $crate::notification::DidChangeNotebookDocumentNotification
+    };
+    ("notebookDocument/didSave") => {
+        $crate::notification::DidSaveNotebookDocumentNotification
+    };
+    ("notebookDocument/didClose") => {
+        $crate::notification::DidCloseNotebookDocumentNotification
+    };
+    ("initialized") => {
+        $crate::notification::InitializedNotification
+    };
+    ("exit") => {
+        $crate::notification::ExitNotification
+    };
+    ("workspace/didChangeConfiguration") => {
+        $crate::notification::DidChangeConfigurationNotification
+    };
+    ("window/showMessage") => {
+        $crate::notification::ShowMessageNotification
+    };
+    ("window/logMessage") => {
+        $crate::notification::LogMessageNotification
+    };
+    ("telemetry/event") => {
+        $crate::notification::TelemetryEventNotification
+    };
+    ("textDocument/didOpen") => {
+        $crate::notification::DidOpenTextDocumentNotification
+    };
+    ("textDocument/didChange") => {
+        $crate::notification::DidChangeTextDocumentNotification
+    };
+    ("textDocument/didClose") => {
+        $crate::notification::DidCloseTextDocumentNotification
+    };
+    ("textDocument/didSave") => {
+        $crate::notification::DidSaveTextDocumentNotification
+    };
+    ("textDocument/willSave") => {
+        $crate::notification::WillSaveTextDocumentNotification
+    };
+    ("workspace/didChangeWatchedFiles") => {
+        $crate::notification::DidChangeWatchedFilesNotification
+    };
+    ("textDocument/publishDiagnostics") => {
+        $crate::notification::PublishDiagnosticsNotification
+    };
+    ("$/setTrace") => {
+        $crate::notification::SetTraceNotification
+    };
+    ("$/logTrace") => {
+        $crate::notification::LogTraceNotification
+    };
+    ("$/cancelRequest") => {
+        $crate::notification::CancelNotification
+    };
+    ("$/progress") => {
+        $crate::notification::ProgressNotification
+    };
 }
 
 #[cfg(all(feature = "macros", feature = "proposed"))]
 #[macro_export]
 macro_rules! lsp_notification {
-    ("workspace/didChangeWorkspaceFolders") => { $crate::notification::DidChangeWorkspaceFoldersNotification };
-    ("window/workDoneProgress/cancel") => { $crate::notification::WorkDoneProgressCancelNotification };
-    ("workspace/didCreateFiles") => { $crate::notification::DidCreateFilesNotification };
-    ("workspace/didRenameFiles") => { $crate::notification::DidRenameFilesNotification };
-    ("workspace/didDeleteFiles") => { $crate::notification::DidDeleteFilesNotification };
-    ("notebookDocument/didOpen") => { $crate::notification::DidOpenNotebookDocumentNotification };
-    ("notebookDocument/didChange") => { $crate::notification::DidChangeNotebookDocumentNotification };
-    ("notebookDocument/didSave") => { $crate::notification::DidSaveNotebookDocumentNotification };
-    ("notebookDocument/didClose") => { $crate::notification::DidCloseNotebookDocumentNotification };
-    ("initialized") => { $crate::notification::InitializedNotification };
-    ("exit") => { $crate::notification::ExitNotification };
-    ("workspace/didChangeConfiguration") => { $crate::notification::DidChangeConfigurationNotification };
-    ("window/showMessage") => { $crate::notification::ShowMessageNotification };
-    ("window/logMessage") => { $crate::notification::LogMessageNotification };
-    ("telemetry/event") => { $crate::notification::TelemetryEventNotification };
-    ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocumentNotification };
-    ("textDocument/didChange") => { $crate::notification::DidChangeTextDocumentNotification };
-    ("textDocument/didClose") => { $crate::notification::DidCloseTextDocumentNotification };
-    ("textDocument/didSave") => { $crate::notification::DidSaveTextDocumentNotification };
-    ("textDocument/willSave") => { $crate::notification::WillSaveTextDocumentNotification };
-    ("workspace/didChangeWatchedFiles") => { $crate::notification::DidChangeWatchedFilesNotification };
-    ("textDocument/publishDiagnostics") => { $crate::notification::PublishDiagnosticsNotification };
-    ("$/setTrace") => { $crate::notification::SetTraceNotification };
-    ("$/logTrace") => { $crate::notification::LogTraceNotification };
-    ("$/cancelRequest") => { $crate::notification::CancelNotification };
-    ("$/progress") => { $crate::notification::ProgressNotification };
+    ("workspace/didChangeWorkspaceFolders") => {
+        $crate::notification::DidChangeWorkspaceFoldersNotification
+    };
+    ("window/workDoneProgress/cancel") => {
+        $crate::notification::WorkDoneProgressCancelNotification
+    };
+    ("workspace/didCreateFiles") => {
+        $crate::notification::DidCreateFilesNotification
+    };
+    ("workspace/didRenameFiles") => {
+        $crate::notification::DidRenameFilesNotification
+    };
+    ("workspace/didDeleteFiles") => {
+        $crate::notification::DidDeleteFilesNotification
+    };
+    ("notebookDocument/didOpen") => {
+        $crate::notification::DidOpenNotebookDocumentNotification
+    };
+    ("notebookDocument/didChange") => {
+        $crate::notification::DidChangeNotebookDocumentNotification
+    };
+    ("notebookDocument/didSave") => {
+        $crate::notification::DidSaveNotebookDocumentNotification
+    };
+    ("notebookDocument/didClose") => {
+        $crate::notification::DidCloseNotebookDocumentNotification
+    };
+    ("initialized") => {
+        $crate::notification::InitializedNotification
+    };
+    ("exit") => {
+        $crate::notification::ExitNotification
+    };
+    ("workspace/didChangeConfiguration") => {
+        $crate::notification::DidChangeConfigurationNotification
+    };
+    ("window/showMessage") => {
+        $crate::notification::ShowMessageNotification
+    };
+    ("window/logMessage") => {
+        $crate::notification::LogMessageNotification
+    };
+    ("telemetry/event") => {
+        $crate::notification::TelemetryEventNotification
+    };
+    ("textDocument/didOpen") => {
+        $crate::notification::DidOpenTextDocumentNotification
+    };
+    ("textDocument/didChange") => {
+        $crate::notification::DidChangeTextDocumentNotification
+    };
+    ("textDocument/didClose") => {
+        $crate::notification::DidCloseTextDocumentNotification
+    };
+    ("textDocument/didSave") => {
+        $crate::notification::DidSaveTextDocumentNotification
+    };
+    ("textDocument/willSave") => {
+        $crate::notification::WillSaveTextDocumentNotification
+    };
+    ("workspace/didChangeWatchedFiles") => {
+        $crate::notification::DidChangeWatchedFilesNotification
+    };
+    ("textDocument/publishDiagnostics") => {
+        $crate::notification::PublishDiagnosticsNotification
+    };
+    ("$/setTrace") => {
+        $crate::notification::SetTraceNotification
+    };
+    ("$/logTrace") => {
+        $crate::notification::LogTraceNotification
+    };
+    ("$/cancelRequest") => {
+        $crate::notification::CancelNotification
+    };
+    ("$/progress") => {
+        $crate::notification::ProgressNotification
+    };
 }
-
 
 pub enum DidChangeWorkspaceFoldersNotification {}
 impl Notification for DidChangeWorkspaceFoldersNotification {

--- a/lspt/src/generated/notification.rs
+++ b/lspt/src/generated/notification.rs
@@ -1,7 +1,7 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
-use super::*;
 use serde::Serialize;
+use super::*;
 
 pub trait Notification {
     const METHOD: &'static str;
@@ -11,168 +11,65 @@ pub trait Notification {
 #[cfg(all(feature = "macros", not(feature = "proposed")))]
 #[macro_export]
 macro_rules! lsp_notification {
-    ("workspace/didChangeWorkspaceFolders") => {
-        $crate::notification::DidChangeWorkspaceFoldersNotification
-    };
-    ("window/workDoneProgress/cancel") => {
-        $crate::notification::WorkDoneProgressCancelNotification
-    };
-    ("workspace/didCreateFiles") => {
-        $crate::notification::DidCreateFilesNotification
-    };
-    ("workspace/didRenameFiles") => {
-        $crate::notification::DidRenameFilesNotification
-    };
-    ("workspace/didDeleteFiles") => {
-        $crate::notification::DidDeleteFilesNotification
-    };
-    ("notebookDocument/didOpen") => {
-        $crate::notification::DidOpenNotebookDocumentNotification
-    };
-    ("notebookDocument/didChange") => {
-        $crate::notification::DidChangeNotebookDocumentNotification
-    };
-    ("notebookDocument/didSave") => {
-        $crate::notification::DidSaveNotebookDocumentNotification
-    };
-    ("notebookDocument/didClose") => {
-        $crate::notification::DidCloseNotebookDocumentNotification
-    };
-    ("initialized") => {
-        $crate::notification::InitializedNotification
-    };
-    ("exit") => {
-        $crate::notification::ExitNotification
-    };
-    ("workspace/didChangeConfiguration") => {
-        $crate::notification::DidChangeConfigurationNotification
-    };
-    ("window/showMessage") => {
-        $crate::notification::ShowMessageNotification
-    };
-    ("window/logMessage") => {
-        $crate::notification::LogMessageNotification
-    };
-    ("telemetry/event") => {
-        $crate::notification::TelemetryEventNotification
-    };
-    ("textDocument/didOpen") => {
-        $crate::notification::DidOpenTextDocumentNotification
-    };
-    ("textDocument/didChange") => {
-        $crate::notification::DidChangeTextDocumentNotification
-    };
-    ("textDocument/didClose") => {
-        $crate::notification::DidCloseTextDocumentNotification
-    };
-    ("textDocument/didSave") => {
-        $crate::notification::DidSaveTextDocumentNotification
-    };
-    ("textDocument/willSave") => {
-        $crate::notification::WillSaveTextDocumentNotification
-    };
-    ("workspace/didChangeWatchedFiles") => {
-        $crate::notification::DidChangeWatchedFilesNotification
-    };
-    ("textDocument/publishDiagnostics") => {
-        $crate::notification::PublishDiagnosticsNotification
-    };
-    ("$/setTrace") => {
-        $crate::notification::SetTraceNotification
-    };
-    ("$/logTrace") => {
-        $crate::notification::LogTraceNotification
-    };
-    ("$/cancelRequest") => {
-        $crate::notification::CancelNotification
-    };
-    ("$/progress") => {
-        $crate::notification::ProgressNotification
-    };
+    ("workspace/didChangeWorkspaceFolders") => { $crate::notification::DidChangeWorkspaceFoldersNotification };
+    ("window/workDoneProgress/cancel") => { $crate::notification::WorkDoneProgressCancelNotification };
+    ("workspace/didCreateFiles") => { $crate::notification::DidCreateFilesNotification };
+    ("workspace/didRenameFiles") => { $crate::notification::DidRenameFilesNotification };
+    ("workspace/didDeleteFiles") => { $crate::notification::DidDeleteFilesNotification };
+    ("notebookDocument/didOpen") => { $crate::notification::DidOpenNotebookDocumentNotification };
+    ("notebookDocument/didChange") => { $crate::notification::DidChangeNotebookDocumentNotification };
+    ("notebookDocument/didSave") => { $crate::notification::DidSaveNotebookDocumentNotification };
+    ("notebookDocument/didClose") => { $crate::notification::DidCloseNotebookDocumentNotification };
+    ("initialized") => { $crate::notification::InitializedNotification };
+    ("exit") => { $crate::notification::ExitNotification };
+    ("workspace/didChangeConfiguration") => { $crate::notification::DidChangeConfigurationNotification };
+    ("window/showMessage") => { $crate::notification::ShowMessageNotification };
+    ("window/logMessage") => { $crate::notification::LogMessageNotification };
+    ("telemetry/event") => { $crate::notification::TelemetryEventNotification };
+    ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocumentNotification };
+    ("textDocument/didChange") => { $crate::notification::DidChangeTextDocumentNotification };
+    ("textDocument/didClose") => { $crate::notification::DidCloseTextDocumentNotification };
+    ("textDocument/didSave") => { $crate::notification::DidSaveTextDocumentNotification };
+    ("textDocument/willSave") => { $crate::notification::WillSaveTextDocumentNotification };
+    ("workspace/didChangeWatchedFiles") => { $crate::notification::DidChangeWatchedFilesNotification };
+    ("textDocument/publishDiagnostics") => { $crate::notification::PublishDiagnosticsNotification };
+    ("$/setTrace") => { $crate::notification::SetTraceNotification };
+    ("$/logTrace") => { $crate::notification::LogTraceNotification };
+    ("$/cancelRequest") => { $crate::notification::CancelNotification };
+    ("$/progress") => { $crate::notification::ProgressNotification };
 }
 
 #[cfg(all(feature = "macros", feature = "proposed"))]
 #[macro_export]
 macro_rules! lsp_notification {
-    ("workspace/didChangeWorkspaceFolders") => {
-        $crate::notification::DidChangeWorkspaceFoldersNotification
-    };
-    ("window/workDoneProgress/cancel") => {
-        $crate::notification::WorkDoneProgressCancelNotification
-    };
-    ("workspace/didCreateFiles") => {
-        $crate::notification::DidCreateFilesNotification
-    };
-    ("workspace/didRenameFiles") => {
-        $crate::notification::DidRenameFilesNotification
-    };
-    ("workspace/didDeleteFiles") => {
-        $crate::notification::DidDeleteFilesNotification
-    };
-    ("notebookDocument/didOpen") => {
-        $crate::notification::DidOpenNotebookDocumentNotification
-    };
-    ("notebookDocument/didChange") => {
-        $crate::notification::DidChangeNotebookDocumentNotification
-    };
-    ("notebookDocument/didSave") => {
-        $crate::notification::DidSaveNotebookDocumentNotification
-    };
-    ("notebookDocument/didClose") => {
-        $crate::notification::DidCloseNotebookDocumentNotification
-    };
-    ("initialized") => {
-        $crate::notification::InitializedNotification
-    };
-    ("exit") => {
-        $crate::notification::ExitNotification
-    };
-    ("workspace/didChangeConfiguration") => {
-        $crate::notification::DidChangeConfigurationNotification
-    };
-    ("window/showMessage") => {
-        $crate::notification::ShowMessageNotification
-    };
-    ("window/logMessage") => {
-        $crate::notification::LogMessageNotification
-    };
-    ("telemetry/event") => {
-        $crate::notification::TelemetryEventNotification
-    };
-    ("textDocument/didOpen") => {
-        $crate::notification::DidOpenTextDocumentNotification
-    };
-    ("textDocument/didChange") => {
-        $crate::notification::DidChangeTextDocumentNotification
-    };
-    ("textDocument/didClose") => {
-        $crate::notification::DidCloseTextDocumentNotification
-    };
-    ("textDocument/didSave") => {
-        $crate::notification::DidSaveTextDocumentNotification
-    };
-    ("textDocument/willSave") => {
-        $crate::notification::WillSaveTextDocumentNotification
-    };
-    ("workspace/didChangeWatchedFiles") => {
-        $crate::notification::DidChangeWatchedFilesNotification
-    };
-    ("textDocument/publishDiagnostics") => {
-        $crate::notification::PublishDiagnosticsNotification
-    };
-    ("$/setTrace") => {
-        $crate::notification::SetTraceNotification
-    };
-    ("$/logTrace") => {
-        $crate::notification::LogTraceNotification
-    };
-    ("$/cancelRequest") => {
-        $crate::notification::CancelNotification
-    };
-    ("$/progress") => {
-        $crate::notification::ProgressNotification
-    };
+    ("workspace/didChangeWorkspaceFolders") => { $crate::notification::DidChangeWorkspaceFoldersNotification };
+    ("window/workDoneProgress/cancel") => { $crate::notification::WorkDoneProgressCancelNotification };
+    ("workspace/didCreateFiles") => { $crate::notification::DidCreateFilesNotification };
+    ("workspace/didRenameFiles") => { $crate::notification::DidRenameFilesNotification };
+    ("workspace/didDeleteFiles") => { $crate::notification::DidDeleteFilesNotification };
+    ("notebookDocument/didOpen") => { $crate::notification::DidOpenNotebookDocumentNotification };
+    ("notebookDocument/didChange") => { $crate::notification::DidChangeNotebookDocumentNotification };
+    ("notebookDocument/didSave") => { $crate::notification::DidSaveNotebookDocumentNotification };
+    ("notebookDocument/didClose") => { $crate::notification::DidCloseNotebookDocumentNotification };
+    ("initialized") => { $crate::notification::InitializedNotification };
+    ("exit") => { $crate::notification::ExitNotification };
+    ("workspace/didChangeConfiguration") => { $crate::notification::DidChangeConfigurationNotification };
+    ("window/showMessage") => { $crate::notification::ShowMessageNotification };
+    ("window/logMessage") => { $crate::notification::LogMessageNotification };
+    ("telemetry/event") => { $crate::notification::TelemetryEventNotification };
+    ("textDocument/didOpen") => { $crate::notification::DidOpenTextDocumentNotification };
+    ("textDocument/didChange") => { $crate::notification::DidChangeTextDocumentNotification };
+    ("textDocument/didClose") => { $crate::notification::DidCloseTextDocumentNotification };
+    ("textDocument/didSave") => { $crate::notification::DidSaveTextDocumentNotification };
+    ("textDocument/willSave") => { $crate::notification::WillSaveTextDocumentNotification };
+    ("workspace/didChangeWatchedFiles") => { $crate::notification::DidChangeWatchedFilesNotification };
+    ("textDocument/publishDiagnostics") => { $crate::notification::PublishDiagnosticsNotification };
+    ("$/setTrace") => { $crate::notification::SetTraceNotification };
+    ("$/logTrace") => { $crate::notification::LogTraceNotification };
+    ("$/cancelRequest") => { $crate::notification::CancelNotification };
+    ("$/progress") => { $crate::notification::ProgressNotification };
 }
+
 
 pub enum DidChangeWorkspaceFoldersNotification {}
 impl Notification for DidChangeWorkspaceFoldersNotification {

--- a/lspt/src/generated/request.rs
+++ b/lspt/src/generated/request.rs
@@ -1,8 +1,7 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
-use crate::{Union2, Union3, Union4};
-use serde::Serialize;
 use super::*;
+use serde::Serialize;
 
 pub trait Request {
     const METHOD: &'static str;
@@ -13,159 +12,424 @@ pub trait Request {
 #[cfg(all(feature = "macros", not(feature = "proposed")))]
 #[macro_export]
 macro_rules! lsp_request {
-    ("textDocument/implementation") => { $crate::request::ImplementationRequest };
-    ("textDocument/typeDefinition") => { $crate::request::TypeDefinitionRequest };
-    ("workspace/workspaceFolders") => { $crate::request::WorkspaceFoldersRequest };
-    ("workspace/configuration") => { $crate::request::ConfigurationRequest };
-    ("textDocument/documentColor") => { $crate::request::DocumentColorRequest };
-    ("textDocument/colorPresentation") => { $crate::request::ColorPresentationRequest };
-    ("textDocument/foldingRange") => { $crate::request::FoldingRangeRequest };
-    ("textDocument/declaration") => { $crate::request::DeclarationRequest };
-    ("textDocument/selectionRange") => { $crate::request::SelectionRangeRequest };
-    ("window/workDoneProgress/create") => { $crate::request::WorkDoneProgressCreateRequest };
-    ("textDocument/prepareCallHierarchy") => { $crate::request::CallHierarchyPrepareRequest };
-    ("callHierarchy/incomingCalls") => { $crate::request::CallHierarchyIncomingCallsRequest };
-    ("callHierarchy/outgoingCalls") => { $crate::request::CallHierarchyOutgoingCallsRequest };
-    ("textDocument/semanticTokens/full") => { $crate::request::SemanticTokensRequest };
-    ("textDocument/semanticTokens/full/delta") => { $crate::request::SemanticTokensDeltaRequest };
-    ("textDocument/semanticTokens/range") => { $crate::request::SemanticTokensRangeRequest };
-    ("workspace/semanticTokens/refresh") => { $crate::request::SemanticTokensRefreshRequest };
-    ("window/showDocument") => { $crate::request::ShowDocumentRequest };
-    ("textDocument/linkedEditingRange") => { $crate::request::LinkedEditingRangeRequest };
-    ("workspace/willCreateFiles") => { $crate::request::WillCreateFilesRequest };
-    ("workspace/willRenameFiles") => { $crate::request::WillRenameFilesRequest };
-    ("workspace/willDeleteFiles") => { $crate::request::WillDeleteFilesRequest };
-    ("textDocument/moniker") => { $crate::request::MonikerRequest };
-    ("textDocument/prepareTypeHierarchy") => { $crate::request::TypeHierarchyPrepareRequest };
-    ("typeHierarchy/supertypes") => { $crate::request::TypeHierarchySupertypesRequest };
-    ("typeHierarchy/subtypes") => { $crate::request::TypeHierarchySubtypesRequest };
-    ("textDocument/inlineValue") => { $crate::request::InlineValueRequest };
-    ("workspace/inlineValue/refresh") => { $crate::request::InlineValueRefreshRequest };
-    ("textDocument/inlayHint") => { $crate::request::InlayHintRequest };
-    ("inlayHint/resolve") => { $crate::request::InlayHintResolveRequest };
-    ("workspace/inlayHint/refresh") => { $crate::request::InlayHintRefreshRequest };
-    ("textDocument/diagnostic") => { $crate::request::DocumentDiagnosticRequest };
-    ("workspace/diagnostic") => { $crate::request::WorkspaceDiagnosticRequest };
-    ("workspace/diagnostic/refresh") => { $crate::request::DiagnosticRefreshRequest };
-    ("client/registerCapability") => { $crate::request::RegistrationRequest };
-    ("client/unregisterCapability") => { $crate::request::UnregistrationRequest };
-    ("initialize") => { $crate::request::InitializeRequest };
-    ("shutdown") => { $crate::request::ShutdownRequest };
-    ("window/showMessageRequest") => { $crate::request::ShowMessageRequest };
-    ("textDocument/willSaveWaitUntil") => { $crate::request::WillSaveTextDocumentWaitUntilRequest };
-    ("textDocument/completion") => { $crate::request::CompletionRequest };
-    ("completionItem/resolve") => { $crate::request::CompletionResolveRequest };
-    ("textDocument/hover") => { $crate::request::HoverRequest };
-    ("textDocument/signatureHelp") => { $crate::request::SignatureHelpRequest };
-    ("textDocument/definition") => { $crate::request::DefinitionRequest };
-    ("textDocument/references") => { $crate::request::ReferencesRequest };
-    ("textDocument/documentHighlight") => { $crate::request::DocumentHighlightRequest };
-    ("textDocument/documentSymbol") => { $crate::request::DocumentSymbolRequest };
-    ("textDocument/codeAction") => { $crate::request::CodeActionRequest };
-    ("codeAction/resolve") => { $crate::request::CodeActionResolveRequest };
-    ("workspace/symbol") => { $crate::request::WorkspaceSymbolRequest };
-    ("workspaceSymbol/resolve") => { $crate::request::WorkspaceSymbolResolveRequest };
-    ("textDocument/codeLens") => { $crate::request::CodeLensRequest };
-    ("codeLens/resolve") => { $crate::request::CodeLensResolveRequest };
-    ("workspace/codeLens/refresh") => { $crate::request::CodeLensRefreshRequest };
-    ("textDocument/documentLink") => { $crate::request::DocumentLinkRequest };
-    ("documentLink/resolve") => { $crate::request::DocumentLinkResolveRequest };
-    ("textDocument/formatting") => { $crate::request::DocumentFormattingRequest };
-    ("textDocument/rangeFormatting") => { $crate::request::DocumentRangeFormattingRequest };
-    ("textDocument/onTypeFormatting") => { $crate::request::DocumentOnTypeFormattingRequest };
-    ("textDocument/rename") => { $crate::request::RenameRequest };
-    ("textDocument/prepareRename") => { $crate::request::PrepareRenameRequest };
-    ("workspace/executeCommand") => { $crate::request::ExecuteCommandRequest };
-    ("workspace/applyEdit") => { $crate::request::ApplyWorkspaceEditRequest };
+    ("textDocument/implementation") => {
+        $crate::request::ImplementationRequest
+    };
+    ("textDocument/typeDefinition") => {
+        $crate::request::TypeDefinitionRequest
+    };
+    ("workspace/workspaceFolders") => {
+        $crate::request::WorkspaceFoldersRequest
+    };
+    ("workspace/configuration") => {
+        $crate::request::ConfigurationRequest
+    };
+    ("textDocument/documentColor") => {
+        $crate::request::DocumentColorRequest
+    };
+    ("textDocument/colorPresentation") => {
+        $crate::request::ColorPresentationRequest
+    };
+    ("textDocument/foldingRange") => {
+        $crate::request::FoldingRangeRequest
+    };
+    ("textDocument/declaration") => {
+        $crate::request::DeclarationRequest
+    };
+    ("textDocument/selectionRange") => {
+        $crate::request::SelectionRangeRequest
+    };
+    ("window/workDoneProgress/create") => {
+        $crate::request::WorkDoneProgressCreateRequest
+    };
+    ("textDocument/prepareCallHierarchy") => {
+        $crate::request::CallHierarchyPrepareRequest
+    };
+    ("callHierarchy/incomingCalls") => {
+        $crate::request::CallHierarchyIncomingCallsRequest
+    };
+    ("callHierarchy/outgoingCalls") => {
+        $crate::request::CallHierarchyOutgoingCallsRequest
+    };
+    ("textDocument/semanticTokens/full") => {
+        $crate::request::SemanticTokensRequest
+    };
+    ("textDocument/semanticTokens/full/delta") => {
+        $crate::request::SemanticTokensDeltaRequest
+    };
+    ("textDocument/semanticTokens/range") => {
+        $crate::request::SemanticTokensRangeRequest
+    };
+    ("workspace/semanticTokens/refresh") => {
+        $crate::request::SemanticTokensRefreshRequest
+    };
+    ("window/showDocument") => {
+        $crate::request::ShowDocumentRequest
+    };
+    ("textDocument/linkedEditingRange") => {
+        $crate::request::LinkedEditingRangeRequest
+    };
+    ("workspace/willCreateFiles") => {
+        $crate::request::WillCreateFilesRequest
+    };
+    ("workspace/willRenameFiles") => {
+        $crate::request::WillRenameFilesRequest
+    };
+    ("workspace/willDeleteFiles") => {
+        $crate::request::WillDeleteFilesRequest
+    };
+    ("textDocument/moniker") => {
+        $crate::request::MonikerRequest
+    };
+    ("textDocument/prepareTypeHierarchy") => {
+        $crate::request::TypeHierarchyPrepareRequest
+    };
+    ("typeHierarchy/supertypes") => {
+        $crate::request::TypeHierarchySupertypesRequest
+    };
+    ("typeHierarchy/subtypes") => {
+        $crate::request::TypeHierarchySubtypesRequest
+    };
+    ("textDocument/inlineValue") => {
+        $crate::request::InlineValueRequest
+    };
+    ("workspace/inlineValue/refresh") => {
+        $crate::request::InlineValueRefreshRequest
+    };
+    ("textDocument/inlayHint") => {
+        $crate::request::InlayHintRequest
+    };
+    ("inlayHint/resolve") => {
+        $crate::request::InlayHintResolveRequest
+    };
+    ("workspace/inlayHint/refresh") => {
+        $crate::request::InlayHintRefreshRequest
+    };
+    ("textDocument/diagnostic") => {
+        $crate::request::DocumentDiagnosticRequest
+    };
+    ("workspace/diagnostic") => {
+        $crate::request::WorkspaceDiagnosticRequest
+    };
+    ("workspace/diagnostic/refresh") => {
+        $crate::request::DiagnosticRefreshRequest
+    };
+    ("client/registerCapability") => {
+        $crate::request::RegistrationRequest
+    };
+    ("client/unregisterCapability") => {
+        $crate::request::UnregistrationRequest
+    };
+    ("initialize") => {
+        $crate::request::InitializeRequest
+    };
+    ("shutdown") => {
+        $crate::request::ShutdownRequest
+    };
+    ("window/showMessageRequest") => {
+        $crate::request::ShowMessageRequest
+    };
+    ("textDocument/willSaveWaitUntil") => {
+        $crate::request::WillSaveTextDocumentWaitUntilRequest
+    };
+    ("textDocument/completion") => {
+        $crate::request::CompletionRequest
+    };
+    ("completionItem/resolve") => {
+        $crate::request::CompletionResolveRequest
+    };
+    ("textDocument/hover") => {
+        $crate::request::HoverRequest
+    };
+    ("textDocument/signatureHelp") => {
+        $crate::request::SignatureHelpRequest
+    };
+    ("textDocument/definition") => {
+        $crate::request::DefinitionRequest
+    };
+    ("textDocument/references") => {
+        $crate::request::ReferencesRequest
+    };
+    ("textDocument/documentHighlight") => {
+        $crate::request::DocumentHighlightRequest
+    };
+    ("textDocument/documentSymbol") => {
+        $crate::request::DocumentSymbolRequest
+    };
+    ("textDocument/codeAction") => {
+        $crate::request::CodeActionRequest
+    };
+    ("codeAction/resolve") => {
+        $crate::request::CodeActionResolveRequest
+    };
+    ("workspace/symbol") => {
+        $crate::request::WorkspaceSymbolRequest
+    };
+    ("workspaceSymbol/resolve") => {
+        $crate::request::WorkspaceSymbolResolveRequest
+    };
+    ("textDocument/codeLens") => {
+        $crate::request::CodeLensRequest
+    };
+    ("codeLens/resolve") => {
+        $crate::request::CodeLensResolveRequest
+    };
+    ("workspace/codeLens/refresh") => {
+        $crate::request::CodeLensRefreshRequest
+    };
+    ("textDocument/documentLink") => {
+        $crate::request::DocumentLinkRequest
+    };
+    ("documentLink/resolve") => {
+        $crate::request::DocumentLinkResolveRequest
+    };
+    ("textDocument/formatting") => {
+        $crate::request::DocumentFormattingRequest
+    };
+    ("textDocument/rangeFormatting") => {
+        $crate::request::DocumentRangeFormattingRequest
+    };
+    ("textDocument/onTypeFormatting") => {
+        $crate::request::DocumentOnTypeFormattingRequest
+    };
+    ("textDocument/rename") => {
+        $crate::request::RenameRequest
+    };
+    ("textDocument/prepareRename") => {
+        $crate::request::PrepareRenameRequest
+    };
+    ("workspace/executeCommand") => {
+        $crate::request::ExecuteCommandRequest
+    };
+    ("workspace/applyEdit") => {
+        $crate::request::ApplyWorkspaceEditRequest
+    };
 }
 
 #[cfg(all(feature = "macros", feature = "proposed"))]
 #[macro_export]
 macro_rules! lsp_request {
-    ("textDocument/implementation") => { $crate::request::ImplementationRequest };
-    ("textDocument/typeDefinition") => { $crate::request::TypeDefinitionRequest };
-    ("workspace/workspaceFolders") => { $crate::request::WorkspaceFoldersRequest };
-    ("workspace/configuration") => { $crate::request::ConfigurationRequest };
-    ("textDocument/documentColor") => { $crate::request::DocumentColorRequest };
-    ("textDocument/colorPresentation") => { $crate::request::ColorPresentationRequest };
-    ("textDocument/foldingRange") => { $crate::request::FoldingRangeRequest };
-    ("workspace/foldingRange/refresh") => { $crate::request::FoldingRangeRefreshRequest };
-    ("textDocument/declaration") => { $crate::request::DeclarationRequest };
-    ("textDocument/selectionRange") => { $crate::request::SelectionRangeRequest };
-    ("window/workDoneProgress/create") => { $crate::request::WorkDoneProgressCreateRequest };
-    ("textDocument/prepareCallHierarchy") => { $crate::request::CallHierarchyPrepareRequest };
-    ("callHierarchy/incomingCalls") => { $crate::request::CallHierarchyIncomingCallsRequest };
-    ("callHierarchy/outgoingCalls") => { $crate::request::CallHierarchyOutgoingCallsRequest };
-    ("textDocument/semanticTokens/full") => { $crate::request::SemanticTokensRequest };
-    ("textDocument/semanticTokens/full/delta") => { $crate::request::SemanticTokensDeltaRequest };
-    ("textDocument/semanticTokens/range") => { $crate::request::SemanticTokensRangeRequest };
-    ("workspace/semanticTokens/refresh") => { $crate::request::SemanticTokensRefreshRequest };
-    ("window/showDocument") => { $crate::request::ShowDocumentRequest };
-    ("textDocument/linkedEditingRange") => { $crate::request::LinkedEditingRangeRequest };
-    ("workspace/willCreateFiles") => { $crate::request::WillCreateFilesRequest };
-    ("workspace/willRenameFiles") => { $crate::request::WillRenameFilesRequest };
-    ("workspace/willDeleteFiles") => { $crate::request::WillDeleteFilesRequest };
-    ("textDocument/moniker") => { $crate::request::MonikerRequest };
-    ("textDocument/prepareTypeHierarchy") => { $crate::request::TypeHierarchyPrepareRequest };
-    ("typeHierarchy/supertypes") => { $crate::request::TypeHierarchySupertypesRequest };
-    ("typeHierarchy/subtypes") => { $crate::request::TypeHierarchySubtypesRequest };
-    ("textDocument/inlineValue") => { $crate::request::InlineValueRequest };
-    ("workspace/inlineValue/refresh") => { $crate::request::InlineValueRefreshRequest };
-    ("textDocument/inlayHint") => { $crate::request::InlayHintRequest };
-    ("inlayHint/resolve") => { $crate::request::InlayHintResolveRequest };
-    ("workspace/inlayHint/refresh") => { $crate::request::InlayHintRefreshRequest };
-    ("textDocument/diagnostic") => { $crate::request::DocumentDiagnosticRequest };
-    ("workspace/diagnostic") => { $crate::request::WorkspaceDiagnosticRequest };
-    ("workspace/diagnostic/refresh") => { $crate::request::DiagnosticRefreshRequest };
-    ("textDocument/inlineCompletion") => { $crate::request::InlineCompletionRequest };
-    ("workspace/textDocumentContent") => { $crate::request::TextDocumentContentRequest };
-    ("workspace/textDocumentContent/refresh") => { $crate::request::TextDocumentContentRefreshRequest };
-    ("client/registerCapability") => { $crate::request::RegistrationRequest };
-    ("client/unregisterCapability") => { $crate::request::UnregistrationRequest };
-    ("initialize") => { $crate::request::InitializeRequest };
-    ("shutdown") => { $crate::request::ShutdownRequest };
-    ("window/showMessageRequest") => { $crate::request::ShowMessageRequest };
-    ("textDocument/willSaveWaitUntil") => { $crate::request::WillSaveTextDocumentWaitUntilRequest };
-    ("textDocument/completion") => { $crate::request::CompletionRequest };
-    ("completionItem/resolve") => { $crate::request::CompletionResolveRequest };
-    ("textDocument/hover") => { $crate::request::HoverRequest };
-    ("textDocument/signatureHelp") => { $crate::request::SignatureHelpRequest };
-    ("textDocument/definition") => { $crate::request::DefinitionRequest };
-    ("textDocument/references") => { $crate::request::ReferencesRequest };
-    ("textDocument/documentHighlight") => { $crate::request::DocumentHighlightRequest };
-    ("textDocument/documentSymbol") => { $crate::request::DocumentSymbolRequest };
-    ("textDocument/codeAction") => { $crate::request::CodeActionRequest };
-    ("codeAction/resolve") => { $crate::request::CodeActionResolveRequest };
-    ("workspace/symbol") => { $crate::request::WorkspaceSymbolRequest };
-    ("workspaceSymbol/resolve") => { $crate::request::WorkspaceSymbolResolveRequest };
-    ("textDocument/codeLens") => { $crate::request::CodeLensRequest };
-    ("codeLens/resolve") => { $crate::request::CodeLensResolveRequest };
-    ("workspace/codeLens/refresh") => { $crate::request::CodeLensRefreshRequest };
-    ("textDocument/documentLink") => { $crate::request::DocumentLinkRequest };
-    ("documentLink/resolve") => { $crate::request::DocumentLinkResolveRequest };
-    ("textDocument/formatting") => { $crate::request::DocumentFormattingRequest };
-    ("textDocument/rangeFormatting") => { $crate::request::DocumentRangeFormattingRequest };
-    ("textDocument/rangesFormatting") => { $crate::request::DocumentRangesFormattingRequest };
-    ("textDocument/onTypeFormatting") => { $crate::request::DocumentOnTypeFormattingRequest };
-    ("textDocument/rename") => { $crate::request::RenameRequest };
-    ("textDocument/prepareRename") => { $crate::request::PrepareRenameRequest };
-    ("workspace/executeCommand") => { $crate::request::ExecuteCommandRequest };
-    ("workspace/applyEdit") => { $crate::request::ApplyWorkspaceEditRequest };
+    ("textDocument/implementation") => {
+        $crate::request::ImplementationRequest
+    };
+    ("textDocument/typeDefinition") => {
+        $crate::request::TypeDefinitionRequest
+    };
+    ("workspace/workspaceFolders") => {
+        $crate::request::WorkspaceFoldersRequest
+    };
+    ("workspace/configuration") => {
+        $crate::request::ConfigurationRequest
+    };
+    ("textDocument/documentColor") => {
+        $crate::request::DocumentColorRequest
+    };
+    ("textDocument/colorPresentation") => {
+        $crate::request::ColorPresentationRequest
+    };
+    ("textDocument/foldingRange") => {
+        $crate::request::FoldingRangeRequest
+    };
+    ("workspace/foldingRange/refresh") => {
+        $crate::request::FoldingRangeRefreshRequest
+    };
+    ("textDocument/declaration") => {
+        $crate::request::DeclarationRequest
+    };
+    ("textDocument/selectionRange") => {
+        $crate::request::SelectionRangeRequest
+    };
+    ("window/workDoneProgress/create") => {
+        $crate::request::WorkDoneProgressCreateRequest
+    };
+    ("textDocument/prepareCallHierarchy") => {
+        $crate::request::CallHierarchyPrepareRequest
+    };
+    ("callHierarchy/incomingCalls") => {
+        $crate::request::CallHierarchyIncomingCallsRequest
+    };
+    ("callHierarchy/outgoingCalls") => {
+        $crate::request::CallHierarchyOutgoingCallsRequest
+    };
+    ("textDocument/semanticTokens/full") => {
+        $crate::request::SemanticTokensRequest
+    };
+    ("textDocument/semanticTokens/full/delta") => {
+        $crate::request::SemanticTokensDeltaRequest
+    };
+    ("textDocument/semanticTokens/range") => {
+        $crate::request::SemanticTokensRangeRequest
+    };
+    ("workspace/semanticTokens/refresh") => {
+        $crate::request::SemanticTokensRefreshRequest
+    };
+    ("window/showDocument") => {
+        $crate::request::ShowDocumentRequest
+    };
+    ("textDocument/linkedEditingRange") => {
+        $crate::request::LinkedEditingRangeRequest
+    };
+    ("workspace/willCreateFiles") => {
+        $crate::request::WillCreateFilesRequest
+    };
+    ("workspace/willRenameFiles") => {
+        $crate::request::WillRenameFilesRequest
+    };
+    ("workspace/willDeleteFiles") => {
+        $crate::request::WillDeleteFilesRequest
+    };
+    ("textDocument/moniker") => {
+        $crate::request::MonikerRequest
+    };
+    ("textDocument/prepareTypeHierarchy") => {
+        $crate::request::TypeHierarchyPrepareRequest
+    };
+    ("typeHierarchy/supertypes") => {
+        $crate::request::TypeHierarchySupertypesRequest
+    };
+    ("typeHierarchy/subtypes") => {
+        $crate::request::TypeHierarchySubtypesRequest
+    };
+    ("textDocument/inlineValue") => {
+        $crate::request::InlineValueRequest
+    };
+    ("workspace/inlineValue/refresh") => {
+        $crate::request::InlineValueRefreshRequest
+    };
+    ("textDocument/inlayHint") => {
+        $crate::request::InlayHintRequest
+    };
+    ("inlayHint/resolve") => {
+        $crate::request::InlayHintResolveRequest
+    };
+    ("workspace/inlayHint/refresh") => {
+        $crate::request::InlayHintRefreshRequest
+    };
+    ("textDocument/diagnostic") => {
+        $crate::request::DocumentDiagnosticRequest
+    };
+    ("workspace/diagnostic") => {
+        $crate::request::WorkspaceDiagnosticRequest
+    };
+    ("workspace/diagnostic/refresh") => {
+        $crate::request::DiagnosticRefreshRequest
+    };
+    ("textDocument/inlineCompletion") => {
+        $crate::request::InlineCompletionRequest
+    };
+    ("workspace/textDocumentContent") => {
+        $crate::request::TextDocumentContentRequest
+    };
+    ("workspace/textDocumentContent/refresh") => {
+        $crate::request::TextDocumentContentRefreshRequest
+    };
+    ("client/registerCapability") => {
+        $crate::request::RegistrationRequest
+    };
+    ("client/unregisterCapability") => {
+        $crate::request::UnregistrationRequest
+    };
+    ("initialize") => {
+        $crate::request::InitializeRequest
+    };
+    ("shutdown") => {
+        $crate::request::ShutdownRequest
+    };
+    ("window/showMessageRequest") => {
+        $crate::request::ShowMessageRequest
+    };
+    ("textDocument/willSaveWaitUntil") => {
+        $crate::request::WillSaveTextDocumentWaitUntilRequest
+    };
+    ("textDocument/completion") => {
+        $crate::request::CompletionRequest
+    };
+    ("completionItem/resolve") => {
+        $crate::request::CompletionResolveRequest
+    };
+    ("textDocument/hover") => {
+        $crate::request::HoverRequest
+    };
+    ("textDocument/signatureHelp") => {
+        $crate::request::SignatureHelpRequest
+    };
+    ("textDocument/definition") => {
+        $crate::request::DefinitionRequest
+    };
+    ("textDocument/references") => {
+        $crate::request::ReferencesRequest
+    };
+    ("textDocument/documentHighlight") => {
+        $crate::request::DocumentHighlightRequest
+    };
+    ("textDocument/documentSymbol") => {
+        $crate::request::DocumentSymbolRequest
+    };
+    ("textDocument/codeAction") => {
+        $crate::request::CodeActionRequest
+    };
+    ("codeAction/resolve") => {
+        $crate::request::CodeActionResolveRequest
+    };
+    ("workspace/symbol") => {
+        $crate::request::WorkspaceSymbolRequest
+    };
+    ("workspaceSymbol/resolve") => {
+        $crate::request::WorkspaceSymbolResolveRequest
+    };
+    ("textDocument/codeLens") => {
+        $crate::request::CodeLensRequest
+    };
+    ("codeLens/resolve") => {
+        $crate::request::CodeLensResolveRequest
+    };
+    ("workspace/codeLens/refresh") => {
+        $crate::request::CodeLensRefreshRequest
+    };
+    ("textDocument/documentLink") => {
+        $crate::request::DocumentLinkRequest
+    };
+    ("documentLink/resolve") => {
+        $crate::request::DocumentLinkResolveRequest
+    };
+    ("textDocument/formatting") => {
+        $crate::request::DocumentFormattingRequest
+    };
+    ("textDocument/rangeFormatting") => {
+        $crate::request::DocumentRangeFormattingRequest
+    };
+    ("textDocument/rangesFormatting") => {
+        $crate::request::DocumentRangesFormattingRequest
+    };
+    ("textDocument/onTypeFormatting") => {
+        $crate::request::DocumentOnTypeFormattingRequest
+    };
+    ("textDocument/rename") => {
+        $crate::request::RenameRequest
+    };
+    ("textDocument/prepareRename") => {
+        $crate::request::PrepareRenameRequest
+    };
+    ("workspace/executeCommand") => {
+        $crate::request::ExecuteCommandRequest
+    };
+    ("workspace/applyEdit") => {
+        $crate::request::ApplyWorkspaceEditRequest
+    };
 }
-
 
 pub enum ImplementationRequest {}
 impl Request for ImplementationRequest {
     const METHOD: &'static str = "textDocument/implementation";
     type Params = ImplementationParams;
-    type Result = Option<Union3<Definition, Vec<DefinitionLink>, Vec<Location>>>;
+    type Result = Option<ImplementationRequestResult>;
 }
 
 pub enum TypeDefinitionRequest {}
 impl Request for TypeDefinitionRequest {
     const METHOD: &'static str = "textDocument/typeDefinition";
     type Params = TypeDefinitionParams;
-    type Result = Option<Union3<Definition, Vec<DefinitionLink>, Vec<Location>>>;
+    type Result = Option<TypeDefinitionRequestResult>;
 }
 
 pub enum WorkspaceFoldersRequest {}
@@ -216,7 +480,7 @@ pub enum DeclarationRequest {}
 impl Request for DeclarationRequest {
     const METHOD: &'static str = "textDocument/declaration";
     type Params = DeclarationParams;
-    type Result = Option<Union3<Declaration, Vec<DeclarationLink>, Vec<Location>>>;
+    type Result = Option<DeclarationRequestResult>;
 }
 
 pub enum SelectionRangeRequest {}
@@ -258,21 +522,21 @@ pub enum SemanticTokensRequest {}
 impl Request for SemanticTokensRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/full";
     type Params = SemanticTokensParams;
-    type Result = Option<Union2<SemanticTokens, SemanticTokensPartialResult>>;
+    type Result = Option<SemanticTokensRequestResult>;
 }
 
 pub enum SemanticTokensDeltaRequest {}
 impl Request for SemanticTokensDeltaRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/full/delta";
     type Params = SemanticTokensDeltaParams;
-    type Result = Option<Union4<SemanticTokens, SemanticTokensDelta, SemanticTokensPartialResult, SemanticTokensDeltaPartialResult>>;
+    type Result = Option<SemanticTokensDeltaRequestResult>;
 }
 
 pub enum SemanticTokensRangeRequest {}
 impl Request for SemanticTokensRangeRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/range";
     type Params = SemanticTokensRangeParams;
-    type Result = Option<Union2<SemanticTokens, SemanticTokensPartialResult>>;
+    type Result = Option<SemanticTokensRangeRequestResult>;
 }
 
 pub enum SemanticTokensRefreshRequest {}
@@ -384,14 +648,14 @@ pub enum DocumentDiagnosticRequest {}
 impl Request for DocumentDiagnosticRequest {
     const METHOD: &'static str = "textDocument/diagnostic";
     type Params = DocumentDiagnosticParams;
-    type Result = Union2<DocumentDiagnosticReport, DocumentDiagnosticReportPartialResult>;
+    type Result = DocumentDiagnosticRequestResult;
 }
 
 pub enum WorkspaceDiagnosticRequest {}
 impl Request for WorkspaceDiagnosticRequest {
     const METHOD: &'static str = "workspace/diagnostic";
     type Params = WorkspaceDiagnosticParams;
-    type Result = Union2<WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult>;
+    type Result = WorkspaceDiagnosticRequestResult;
 }
 
 pub enum DiagnosticRefreshRequest {}
@@ -407,7 +671,7 @@ pub enum InlineCompletionRequest {}
 impl Request for InlineCompletionRequest {
     const METHOD: &'static str = "textDocument/inlineCompletion";
     type Params = InlineCompletionParams;
-    type Result = Option<Union2<InlineCompletionList, Vec<InlineCompletionItem>>>;
+    type Result = Option<InlineCompletionRequestResult>;
 }
 
 #[cfg(feature = "proposed")]
@@ -474,7 +738,7 @@ pub enum CompletionRequest {}
 impl Request for CompletionRequest {
     const METHOD: &'static str = "textDocument/completion";
     type Params = CompletionParams;
-    type Result = Option<Union2<Vec<CompletionItem>, CompletionList>>;
+    type Result = Option<CompletionRequestResult>;
 }
 
 pub enum CompletionResolveRequest {}
@@ -502,7 +766,7 @@ pub enum DefinitionRequest {}
 impl Request for DefinitionRequest {
     const METHOD: &'static str = "textDocument/definition";
     type Params = DefinitionParams;
-    type Result = Option<Union3<Definition, Vec<DefinitionLink>, Vec<Location>>>;
+    type Result = Option<DefinitionRequestResult>;
 }
 
 pub enum ReferencesRequest {}
@@ -523,14 +787,14 @@ pub enum DocumentSymbolRequest {}
 impl Request for DocumentSymbolRequest {
     const METHOD: &'static str = "textDocument/documentSymbol";
     type Params = DocumentSymbolParams;
-    type Result = Option<Union2<Vec<SymbolInformation>, Vec<DocumentSymbol>>>;
+    type Result = Option<DocumentSymbolRequestResult>;
 }
 
 pub enum CodeActionRequest {}
 impl Request for CodeActionRequest {
     const METHOD: &'static str = "textDocument/codeAction";
     type Params = CodeActionParams;
-    type Result = Option<Vec<Union2<Command, CodeAction>>>;
+    type Result = Option<Vec<CodeActionRequestResultItem>>;
 }
 
 pub enum CodeActionResolveRequest {}
@@ -544,7 +808,7 @@ pub enum WorkspaceSymbolRequest {}
 impl Request for WorkspaceSymbolRequest {
     const METHOD: &'static str = "workspace/symbol";
     type Params = WorkspaceSymbolParams;
-    type Result = Option<Union2<Vec<SymbolInformation>, Vec<WorkspaceSymbol>>>;
+    type Result = Option<WorkspaceSymbolRequestResult>;
 }
 
 pub enum WorkspaceSymbolResolveRequest {}

--- a/lspt/src/generated/request.rs
+++ b/lspt/src/generated/request.rs
@@ -157,14 +157,14 @@ pub enum ImplementationRequest {}
 impl Request for ImplementationRequest {
     const METHOD: &'static str = "textDocument/implementation";
     type Params = ImplementationParams;
-    type Result = Option<ImplementationRequestResult>;
+    type Result = Option<ImplementationResponse>;
 }
 
 pub enum TypeDefinitionRequest {}
 impl Request for TypeDefinitionRequest {
     const METHOD: &'static str = "textDocument/typeDefinition";
     type Params = TypeDefinitionParams;
-    type Result = Option<TypeDefinitionRequestResult>;
+    type Result = Option<TypeDefinitionResponse>;
 }
 
 pub enum WorkspaceFoldersRequest {}
@@ -215,7 +215,7 @@ pub enum DeclarationRequest {}
 impl Request for DeclarationRequest {
     const METHOD: &'static str = "textDocument/declaration";
     type Params = DeclarationParams;
-    type Result = Option<DeclarationRequestResult>;
+    type Result = Option<DeclarationResponse>;
 }
 
 pub enum SelectionRangeRequest {}
@@ -257,21 +257,21 @@ pub enum SemanticTokensRequest {}
 impl Request for SemanticTokensRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/full";
     type Params = SemanticTokensParams;
-    type Result = Option<SemanticTokensRequestResult>;
+    type Result = Option<SemanticTokensResponse>;
 }
 
 pub enum SemanticTokensDeltaRequest {}
 impl Request for SemanticTokensDeltaRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/full/delta";
     type Params = SemanticTokensDeltaParams;
-    type Result = Option<SemanticTokensDeltaRequestResult>;
+    type Result = Option<SemanticTokensDeltaResponse>;
 }
 
 pub enum SemanticTokensRangeRequest {}
 impl Request for SemanticTokensRangeRequest {
     const METHOD: &'static str = "textDocument/semanticTokens/range";
     type Params = SemanticTokensRangeParams;
-    type Result = Option<SemanticTokensRangeRequestResult>;
+    type Result = Option<SemanticTokensRangeResponse>;
 }
 
 pub enum SemanticTokensRefreshRequest {}
@@ -383,14 +383,14 @@ pub enum DocumentDiagnosticRequest {}
 impl Request for DocumentDiagnosticRequest {
     const METHOD: &'static str = "textDocument/diagnostic";
     type Params = DocumentDiagnosticParams;
-    type Result = DocumentDiagnosticRequestResult;
+    type Result = DocumentDiagnosticResponse;
 }
 
 pub enum WorkspaceDiagnosticRequest {}
 impl Request for WorkspaceDiagnosticRequest {
     const METHOD: &'static str = "workspace/diagnostic";
     type Params = WorkspaceDiagnosticParams;
-    type Result = WorkspaceDiagnosticRequestResult;
+    type Result = WorkspaceDiagnosticResponse;
 }
 
 pub enum DiagnosticRefreshRequest {}
@@ -406,7 +406,7 @@ pub enum InlineCompletionRequest {}
 impl Request for InlineCompletionRequest {
     const METHOD: &'static str = "textDocument/inlineCompletion";
     type Params = InlineCompletionParams;
-    type Result = Option<InlineCompletionRequestResult>;
+    type Result = Option<InlineCompletionResponse>;
 }
 
 #[cfg(feature = "proposed")]
@@ -473,7 +473,7 @@ pub enum CompletionRequest {}
 impl Request for CompletionRequest {
     const METHOD: &'static str = "textDocument/completion";
     type Params = CompletionParams;
-    type Result = Option<CompletionRequestResult>;
+    type Result = Option<CompletionResponse>;
 }
 
 pub enum CompletionResolveRequest {}
@@ -501,7 +501,7 @@ pub enum DefinitionRequest {}
 impl Request for DefinitionRequest {
     const METHOD: &'static str = "textDocument/definition";
     type Params = DefinitionParams;
-    type Result = Option<DefinitionRequestResult>;
+    type Result = Option<DefinitionResponse>;
 }
 
 pub enum ReferencesRequest {}
@@ -522,14 +522,14 @@ pub enum DocumentSymbolRequest {}
 impl Request for DocumentSymbolRequest {
     const METHOD: &'static str = "textDocument/documentSymbol";
     type Params = DocumentSymbolParams;
-    type Result = Option<DocumentSymbolRequestResult>;
+    type Result = Option<DocumentSymbolResponse>;
 }
 
 pub enum CodeActionRequest {}
 impl Request for CodeActionRequest {
     const METHOD: &'static str = "textDocument/codeAction";
     type Params = CodeActionParams;
-    type Result = Option<Vec<CodeActionRequestResultItem>>;
+    type Result = Option<Vec<CodeActionResponseItem>>;
 }
 
 pub enum CodeActionResolveRequest {}
@@ -543,7 +543,7 @@ pub enum WorkspaceSymbolRequest {}
 impl Request for WorkspaceSymbolRequest {
     const METHOD: &'static str = "workspace/symbol";
     type Params = WorkspaceSymbolParams;
-    type Result = Option<WorkspaceSymbolRequestResult>;
+    type Result = Option<WorkspaceSymbolResponse>;
 }
 
 pub enum WorkspaceSymbolResolveRequest {}

--- a/lspt/src/generated/request.rs
+++ b/lspt/src/generated/request.rs
@@ -1,7 +1,7 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
-use super::*;
 use serde::Serialize;
+use super::*;
 
 pub trait Request {
     const METHOD: &'static str;
@@ -12,411 +12,146 @@ pub trait Request {
 #[cfg(all(feature = "macros", not(feature = "proposed")))]
 #[macro_export]
 macro_rules! lsp_request {
-    ("textDocument/implementation") => {
-        $crate::request::ImplementationRequest
-    };
-    ("textDocument/typeDefinition") => {
-        $crate::request::TypeDefinitionRequest
-    };
-    ("workspace/workspaceFolders") => {
-        $crate::request::WorkspaceFoldersRequest
-    };
-    ("workspace/configuration") => {
-        $crate::request::ConfigurationRequest
-    };
-    ("textDocument/documentColor") => {
-        $crate::request::DocumentColorRequest
-    };
-    ("textDocument/colorPresentation") => {
-        $crate::request::ColorPresentationRequest
-    };
-    ("textDocument/foldingRange") => {
-        $crate::request::FoldingRangeRequest
-    };
-    ("textDocument/declaration") => {
-        $crate::request::DeclarationRequest
-    };
-    ("textDocument/selectionRange") => {
-        $crate::request::SelectionRangeRequest
-    };
-    ("window/workDoneProgress/create") => {
-        $crate::request::WorkDoneProgressCreateRequest
-    };
-    ("textDocument/prepareCallHierarchy") => {
-        $crate::request::CallHierarchyPrepareRequest
-    };
-    ("callHierarchy/incomingCalls") => {
-        $crate::request::CallHierarchyIncomingCallsRequest
-    };
-    ("callHierarchy/outgoingCalls") => {
-        $crate::request::CallHierarchyOutgoingCallsRequest
-    };
-    ("textDocument/semanticTokens/full") => {
-        $crate::request::SemanticTokensRequest
-    };
-    ("textDocument/semanticTokens/full/delta") => {
-        $crate::request::SemanticTokensDeltaRequest
-    };
-    ("textDocument/semanticTokens/range") => {
-        $crate::request::SemanticTokensRangeRequest
-    };
-    ("workspace/semanticTokens/refresh") => {
-        $crate::request::SemanticTokensRefreshRequest
-    };
-    ("window/showDocument") => {
-        $crate::request::ShowDocumentRequest
-    };
-    ("textDocument/linkedEditingRange") => {
-        $crate::request::LinkedEditingRangeRequest
-    };
-    ("workspace/willCreateFiles") => {
-        $crate::request::WillCreateFilesRequest
-    };
-    ("workspace/willRenameFiles") => {
-        $crate::request::WillRenameFilesRequest
-    };
-    ("workspace/willDeleteFiles") => {
-        $crate::request::WillDeleteFilesRequest
-    };
-    ("textDocument/moniker") => {
-        $crate::request::MonikerRequest
-    };
-    ("textDocument/prepareTypeHierarchy") => {
-        $crate::request::TypeHierarchyPrepareRequest
-    };
-    ("typeHierarchy/supertypes") => {
-        $crate::request::TypeHierarchySupertypesRequest
-    };
-    ("typeHierarchy/subtypes") => {
-        $crate::request::TypeHierarchySubtypesRequest
-    };
-    ("textDocument/inlineValue") => {
-        $crate::request::InlineValueRequest
-    };
-    ("workspace/inlineValue/refresh") => {
-        $crate::request::InlineValueRefreshRequest
-    };
-    ("textDocument/inlayHint") => {
-        $crate::request::InlayHintRequest
-    };
-    ("inlayHint/resolve") => {
-        $crate::request::InlayHintResolveRequest
-    };
-    ("workspace/inlayHint/refresh") => {
-        $crate::request::InlayHintRefreshRequest
-    };
-    ("textDocument/diagnostic") => {
-        $crate::request::DocumentDiagnosticRequest
-    };
-    ("workspace/diagnostic") => {
-        $crate::request::WorkspaceDiagnosticRequest
-    };
-    ("workspace/diagnostic/refresh") => {
-        $crate::request::DiagnosticRefreshRequest
-    };
-    ("client/registerCapability") => {
-        $crate::request::RegistrationRequest
-    };
-    ("client/unregisterCapability") => {
-        $crate::request::UnregistrationRequest
-    };
-    ("initialize") => {
-        $crate::request::InitializeRequest
-    };
-    ("shutdown") => {
-        $crate::request::ShutdownRequest
-    };
-    ("window/showMessageRequest") => {
-        $crate::request::ShowMessageRequest
-    };
-    ("textDocument/willSaveWaitUntil") => {
-        $crate::request::WillSaveTextDocumentWaitUntilRequest
-    };
-    ("textDocument/completion") => {
-        $crate::request::CompletionRequest
-    };
-    ("completionItem/resolve") => {
-        $crate::request::CompletionResolveRequest
-    };
-    ("textDocument/hover") => {
-        $crate::request::HoverRequest
-    };
-    ("textDocument/signatureHelp") => {
-        $crate::request::SignatureHelpRequest
-    };
-    ("textDocument/definition") => {
-        $crate::request::DefinitionRequest
-    };
-    ("textDocument/references") => {
-        $crate::request::ReferencesRequest
-    };
-    ("textDocument/documentHighlight") => {
-        $crate::request::DocumentHighlightRequest
-    };
-    ("textDocument/documentSymbol") => {
-        $crate::request::DocumentSymbolRequest
-    };
-    ("textDocument/codeAction") => {
-        $crate::request::CodeActionRequest
-    };
-    ("codeAction/resolve") => {
-        $crate::request::CodeActionResolveRequest
-    };
-    ("workspace/symbol") => {
-        $crate::request::WorkspaceSymbolRequest
-    };
-    ("workspaceSymbol/resolve") => {
-        $crate::request::WorkspaceSymbolResolveRequest
-    };
-    ("textDocument/codeLens") => {
-        $crate::request::CodeLensRequest
-    };
-    ("codeLens/resolve") => {
-        $crate::request::CodeLensResolveRequest
-    };
-    ("workspace/codeLens/refresh") => {
-        $crate::request::CodeLensRefreshRequest
-    };
-    ("textDocument/documentLink") => {
-        $crate::request::DocumentLinkRequest
-    };
-    ("documentLink/resolve") => {
-        $crate::request::DocumentLinkResolveRequest
-    };
-    ("textDocument/formatting") => {
-        $crate::request::DocumentFormattingRequest
-    };
-    ("textDocument/rangeFormatting") => {
-        $crate::request::DocumentRangeFormattingRequest
-    };
-    ("textDocument/onTypeFormatting") => {
-        $crate::request::DocumentOnTypeFormattingRequest
-    };
-    ("textDocument/rename") => {
-        $crate::request::RenameRequest
-    };
-    ("textDocument/prepareRename") => {
-        $crate::request::PrepareRenameRequest
-    };
-    ("workspace/executeCommand") => {
-        $crate::request::ExecuteCommandRequest
-    };
-    ("workspace/applyEdit") => {
-        $crate::request::ApplyWorkspaceEditRequest
-    };
+    ("textDocument/implementation") => { $crate::request::ImplementationRequest };
+    ("textDocument/typeDefinition") => { $crate::request::TypeDefinitionRequest };
+    ("workspace/workspaceFolders") => { $crate::request::WorkspaceFoldersRequest };
+    ("workspace/configuration") => { $crate::request::ConfigurationRequest };
+    ("textDocument/documentColor") => { $crate::request::DocumentColorRequest };
+    ("textDocument/colorPresentation") => { $crate::request::ColorPresentationRequest };
+    ("textDocument/foldingRange") => { $crate::request::FoldingRangeRequest };
+    ("textDocument/declaration") => { $crate::request::DeclarationRequest };
+    ("textDocument/selectionRange") => { $crate::request::SelectionRangeRequest };
+    ("window/workDoneProgress/create") => { $crate::request::WorkDoneProgressCreateRequest };
+    ("textDocument/prepareCallHierarchy") => { $crate::request::CallHierarchyPrepareRequest };
+    ("callHierarchy/incomingCalls") => { $crate::request::CallHierarchyIncomingCallsRequest };
+    ("callHierarchy/outgoingCalls") => { $crate::request::CallHierarchyOutgoingCallsRequest };
+    ("textDocument/semanticTokens/full") => { $crate::request::SemanticTokensRequest };
+    ("textDocument/semanticTokens/full/delta") => { $crate::request::SemanticTokensDeltaRequest };
+    ("textDocument/semanticTokens/range") => { $crate::request::SemanticTokensRangeRequest };
+    ("workspace/semanticTokens/refresh") => { $crate::request::SemanticTokensRefreshRequest };
+    ("window/showDocument") => { $crate::request::ShowDocumentRequest };
+    ("textDocument/linkedEditingRange") => { $crate::request::LinkedEditingRangeRequest };
+    ("workspace/willCreateFiles") => { $crate::request::WillCreateFilesRequest };
+    ("workspace/willRenameFiles") => { $crate::request::WillRenameFilesRequest };
+    ("workspace/willDeleteFiles") => { $crate::request::WillDeleteFilesRequest };
+    ("textDocument/moniker") => { $crate::request::MonikerRequest };
+    ("textDocument/prepareTypeHierarchy") => { $crate::request::TypeHierarchyPrepareRequest };
+    ("typeHierarchy/supertypes") => { $crate::request::TypeHierarchySupertypesRequest };
+    ("typeHierarchy/subtypes") => { $crate::request::TypeHierarchySubtypesRequest };
+    ("textDocument/inlineValue") => { $crate::request::InlineValueRequest };
+    ("workspace/inlineValue/refresh") => { $crate::request::InlineValueRefreshRequest };
+    ("textDocument/inlayHint") => { $crate::request::InlayHintRequest };
+    ("inlayHint/resolve") => { $crate::request::InlayHintResolveRequest };
+    ("workspace/inlayHint/refresh") => { $crate::request::InlayHintRefreshRequest };
+    ("textDocument/diagnostic") => { $crate::request::DocumentDiagnosticRequest };
+    ("workspace/diagnostic") => { $crate::request::WorkspaceDiagnosticRequest };
+    ("workspace/diagnostic/refresh") => { $crate::request::DiagnosticRefreshRequest };
+    ("client/registerCapability") => { $crate::request::RegistrationRequest };
+    ("client/unregisterCapability") => { $crate::request::UnregistrationRequest };
+    ("initialize") => { $crate::request::InitializeRequest };
+    ("shutdown") => { $crate::request::ShutdownRequest };
+    ("window/showMessageRequest") => { $crate::request::ShowMessageRequest };
+    ("textDocument/willSaveWaitUntil") => { $crate::request::WillSaveTextDocumentWaitUntilRequest };
+    ("textDocument/completion") => { $crate::request::CompletionRequest };
+    ("completionItem/resolve") => { $crate::request::CompletionResolveRequest };
+    ("textDocument/hover") => { $crate::request::HoverRequest };
+    ("textDocument/signatureHelp") => { $crate::request::SignatureHelpRequest };
+    ("textDocument/definition") => { $crate::request::DefinitionRequest };
+    ("textDocument/references") => { $crate::request::ReferencesRequest };
+    ("textDocument/documentHighlight") => { $crate::request::DocumentHighlightRequest };
+    ("textDocument/documentSymbol") => { $crate::request::DocumentSymbolRequest };
+    ("textDocument/codeAction") => { $crate::request::CodeActionRequest };
+    ("codeAction/resolve") => { $crate::request::CodeActionResolveRequest };
+    ("workspace/symbol") => { $crate::request::WorkspaceSymbolRequest };
+    ("workspaceSymbol/resolve") => { $crate::request::WorkspaceSymbolResolveRequest };
+    ("textDocument/codeLens") => { $crate::request::CodeLensRequest };
+    ("codeLens/resolve") => { $crate::request::CodeLensResolveRequest };
+    ("workspace/codeLens/refresh") => { $crate::request::CodeLensRefreshRequest };
+    ("textDocument/documentLink") => { $crate::request::DocumentLinkRequest };
+    ("documentLink/resolve") => { $crate::request::DocumentLinkResolveRequest };
+    ("textDocument/formatting") => { $crate::request::DocumentFormattingRequest };
+    ("textDocument/rangeFormatting") => { $crate::request::DocumentRangeFormattingRequest };
+    ("textDocument/onTypeFormatting") => { $crate::request::DocumentOnTypeFormattingRequest };
+    ("textDocument/rename") => { $crate::request::RenameRequest };
+    ("textDocument/prepareRename") => { $crate::request::PrepareRenameRequest };
+    ("workspace/executeCommand") => { $crate::request::ExecuteCommandRequest };
+    ("workspace/applyEdit") => { $crate::request::ApplyWorkspaceEditRequest };
 }
 
 #[cfg(all(feature = "macros", feature = "proposed"))]
 #[macro_export]
 macro_rules! lsp_request {
-    ("textDocument/implementation") => {
-        $crate::request::ImplementationRequest
-    };
-    ("textDocument/typeDefinition") => {
-        $crate::request::TypeDefinitionRequest
-    };
-    ("workspace/workspaceFolders") => {
-        $crate::request::WorkspaceFoldersRequest
-    };
-    ("workspace/configuration") => {
-        $crate::request::ConfigurationRequest
-    };
-    ("textDocument/documentColor") => {
-        $crate::request::DocumentColorRequest
-    };
-    ("textDocument/colorPresentation") => {
-        $crate::request::ColorPresentationRequest
-    };
-    ("textDocument/foldingRange") => {
-        $crate::request::FoldingRangeRequest
-    };
-    ("workspace/foldingRange/refresh") => {
-        $crate::request::FoldingRangeRefreshRequest
-    };
-    ("textDocument/declaration") => {
-        $crate::request::DeclarationRequest
-    };
-    ("textDocument/selectionRange") => {
-        $crate::request::SelectionRangeRequest
-    };
-    ("window/workDoneProgress/create") => {
-        $crate::request::WorkDoneProgressCreateRequest
-    };
-    ("textDocument/prepareCallHierarchy") => {
-        $crate::request::CallHierarchyPrepareRequest
-    };
-    ("callHierarchy/incomingCalls") => {
-        $crate::request::CallHierarchyIncomingCallsRequest
-    };
-    ("callHierarchy/outgoingCalls") => {
-        $crate::request::CallHierarchyOutgoingCallsRequest
-    };
-    ("textDocument/semanticTokens/full") => {
-        $crate::request::SemanticTokensRequest
-    };
-    ("textDocument/semanticTokens/full/delta") => {
-        $crate::request::SemanticTokensDeltaRequest
-    };
-    ("textDocument/semanticTokens/range") => {
-        $crate::request::SemanticTokensRangeRequest
-    };
-    ("workspace/semanticTokens/refresh") => {
-        $crate::request::SemanticTokensRefreshRequest
-    };
-    ("window/showDocument") => {
-        $crate::request::ShowDocumentRequest
-    };
-    ("textDocument/linkedEditingRange") => {
-        $crate::request::LinkedEditingRangeRequest
-    };
-    ("workspace/willCreateFiles") => {
-        $crate::request::WillCreateFilesRequest
-    };
-    ("workspace/willRenameFiles") => {
-        $crate::request::WillRenameFilesRequest
-    };
-    ("workspace/willDeleteFiles") => {
-        $crate::request::WillDeleteFilesRequest
-    };
-    ("textDocument/moniker") => {
-        $crate::request::MonikerRequest
-    };
-    ("textDocument/prepareTypeHierarchy") => {
-        $crate::request::TypeHierarchyPrepareRequest
-    };
-    ("typeHierarchy/supertypes") => {
-        $crate::request::TypeHierarchySupertypesRequest
-    };
-    ("typeHierarchy/subtypes") => {
-        $crate::request::TypeHierarchySubtypesRequest
-    };
-    ("textDocument/inlineValue") => {
-        $crate::request::InlineValueRequest
-    };
-    ("workspace/inlineValue/refresh") => {
-        $crate::request::InlineValueRefreshRequest
-    };
-    ("textDocument/inlayHint") => {
-        $crate::request::InlayHintRequest
-    };
-    ("inlayHint/resolve") => {
-        $crate::request::InlayHintResolveRequest
-    };
-    ("workspace/inlayHint/refresh") => {
-        $crate::request::InlayHintRefreshRequest
-    };
-    ("textDocument/diagnostic") => {
-        $crate::request::DocumentDiagnosticRequest
-    };
-    ("workspace/diagnostic") => {
-        $crate::request::WorkspaceDiagnosticRequest
-    };
-    ("workspace/diagnostic/refresh") => {
-        $crate::request::DiagnosticRefreshRequest
-    };
-    ("textDocument/inlineCompletion") => {
-        $crate::request::InlineCompletionRequest
-    };
-    ("workspace/textDocumentContent") => {
-        $crate::request::TextDocumentContentRequest
-    };
-    ("workspace/textDocumentContent/refresh") => {
-        $crate::request::TextDocumentContentRefreshRequest
-    };
-    ("client/registerCapability") => {
-        $crate::request::RegistrationRequest
-    };
-    ("client/unregisterCapability") => {
-        $crate::request::UnregistrationRequest
-    };
-    ("initialize") => {
-        $crate::request::InitializeRequest
-    };
-    ("shutdown") => {
-        $crate::request::ShutdownRequest
-    };
-    ("window/showMessageRequest") => {
-        $crate::request::ShowMessageRequest
-    };
-    ("textDocument/willSaveWaitUntil") => {
-        $crate::request::WillSaveTextDocumentWaitUntilRequest
-    };
-    ("textDocument/completion") => {
-        $crate::request::CompletionRequest
-    };
-    ("completionItem/resolve") => {
-        $crate::request::CompletionResolveRequest
-    };
-    ("textDocument/hover") => {
-        $crate::request::HoverRequest
-    };
-    ("textDocument/signatureHelp") => {
-        $crate::request::SignatureHelpRequest
-    };
-    ("textDocument/definition") => {
-        $crate::request::DefinitionRequest
-    };
-    ("textDocument/references") => {
-        $crate::request::ReferencesRequest
-    };
-    ("textDocument/documentHighlight") => {
-        $crate::request::DocumentHighlightRequest
-    };
-    ("textDocument/documentSymbol") => {
-        $crate::request::DocumentSymbolRequest
-    };
-    ("textDocument/codeAction") => {
-        $crate::request::CodeActionRequest
-    };
-    ("codeAction/resolve") => {
-        $crate::request::CodeActionResolveRequest
-    };
-    ("workspace/symbol") => {
-        $crate::request::WorkspaceSymbolRequest
-    };
-    ("workspaceSymbol/resolve") => {
-        $crate::request::WorkspaceSymbolResolveRequest
-    };
-    ("textDocument/codeLens") => {
-        $crate::request::CodeLensRequest
-    };
-    ("codeLens/resolve") => {
-        $crate::request::CodeLensResolveRequest
-    };
-    ("workspace/codeLens/refresh") => {
-        $crate::request::CodeLensRefreshRequest
-    };
-    ("textDocument/documentLink") => {
-        $crate::request::DocumentLinkRequest
-    };
-    ("documentLink/resolve") => {
-        $crate::request::DocumentLinkResolveRequest
-    };
-    ("textDocument/formatting") => {
-        $crate::request::DocumentFormattingRequest
-    };
-    ("textDocument/rangeFormatting") => {
-        $crate::request::DocumentRangeFormattingRequest
-    };
-    ("textDocument/rangesFormatting") => {
-        $crate::request::DocumentRangesFormattingRequest
-    };
-    ("textDocument/onTypeFormatting") => {
-        $crate::request::DocumentOnTypeFormattingRequest
-    };
-    ("textDocument/rename") => {
-        $crate::request::RenameRequest
-    };
-    ("textDocument/prepareRename") => {
-        $crate::request::PrepareRenameRequest
-    };
-    ("workspace/executeCommand") => {
-        $crate::request::ExecuteCommandRequest
-    };
-    ("workspace/applyEdit") => {
-        $crate::request::ApplyWorkspaceEditRequest
-    };
+    ("textDocument/implementation") => { $crate::request::ImplementationRequest };
+    ("textDocument/typeDefinition") => { $crate::request::TypeDefinitionRequest };
+    ("workspace/workspaceFolders") => { $crate::request::WorkspaceFoldersRequest };
+    ("workspace/configuration") => { $crate::request::ConfigurationRequest };
+    ("textDocument/documentColor") => { $crate::request::DocumentColorRequest };
+    ("textDocument/colorPresentation") => { $crate::request::ColorPresentationRequest };
+    ("textDocument/foldingRange") => { $crate::request::FoldingRangeRequest };
+    ("workspace/foldingRange/refresh") => { $crate::request::FoldingRangeRefreshRequest };
+    ("textDocument/declaration") => { $crate::request::DeclarationRequest };
+    ("textDocument/selectionRange") => { $crate::request::SelectionRangeRequest };
+    ("window/workDoneProgress/create") => { $crate::request::WorkDoneProgressCreateRequest };
+    ("textDocument/prepareCallHierarchy") => { $crate::request::CallHierarchyPrepareRequest };
+    ("callHierarchy/incomingCalls") => { $crate::request::CallHierarchyIncomingCallsRequest };
+    ("callHierarchy/outgoingCalls") => { $crate::request::CallHierarchyOutgoingCallsRequest };
+    ("textDocument/semanticTokens/full") => { $crate::request::SemanticTokensRequest };
+    ("textDocument/semanticTokens/full/delta") => { $crate::request::SemanticTokensDeltaRequest };
+    ("textDocument/semanticTokens/range") => { $crate::request::SemanticTokensRangeRequest };
+    ("workspace/semanticTokens/refresh") => { $crate::request::SemanticTokensRefreshRequest };
+    ("window/showDocument") => { $crate::request::ShowDocumentRequest };
+    ("textDocument/linkedEditingRange") => { $crate::request::LinkedEditingRangeRequest };
+    ("workspace/willCreateFiles") => { $crate::request::WillCreateFilesRequest };
+    ("workspace/willRenameFiles") => { $crate::request::WillRenameFilesRequest };
+    ("workspace/willDeleteFiles") => { $crate::request::WillDeleteFilesRequest };
+    ("textDocument/moniker") => { $crate::request::MonikerRequest };
+    ("textDocument/prepareTypeHierarchy") => { $crate::request::TypeHierarchyPrepareRequest };
+    ("typeHierarchy/supertypes") => { $crate::request::TypeHierarchySupertypesRequest };
+    ("typeHierarchy/subtypes") => { $crate::request::TypeHierarchySubtypesRequest };
+    ("textDocument/inlineValue") => { $crate::request::InlineValueRequest };
+    ("workspace/inlineValue/refresh") => { $crate::request::InlineValueRefreshRequest };
+    ("textDocument/inlayHint") => { $crate::request::InlayHintRequest };
+    ("inlayHint/resolve") => { $crate::request::InlayHintResolveRequest };
+    ("workspace/inlayHint/refresh") => { $crate::request::InlayHintRefreshRequest };
+    ("textDocument/diagnostic") => { $crate::request::DocumentDiagnosticRequest };
+    ("workspace/diagnostic") => { $crate::request::WorkspaceDiagnosticRequest };
+    ("workspace/diagnostic/refresh") => { $crate::request::DiagnosticRefreshRequest };
+    ("textDocument/inlineCompletion") => { $crate::request::InlineCompletionRequest };
+    ("workspace/textDocumentContent") => { $crate::request::TextDocumentContentRequest };
+    ("workspace/textDocumentContent/refresh") => { $crate::request::TextDocumentContentRefreshRequest };
+    ("client/registerCapability") => { $crate::request::RegistrationRequest };
+    ("client/unregisterCapability") => { $crate::request::UnregistrationRequest };
+    ("initialize") => { $crate::request::InitializeRequest };
+    ("shutdown") => { $crate::request::ShutdownRequest };
+    ("window/showMessageRequest") => { $crate::request::ShowMessageRequest };
+    ("textDocument/willSaveWaitUntil") => { $crate::request::WillSaveTextDocumentWaitUntilRequest };
+    ("textDocument/completion") => { $crate::request::CompletionRequest };
+    ("completionItem/resolve") => { $crate::request::CompletionResolveRequest };
+    ("textDocument/hover") => { $crate::request::HoverRequest };
+    ("textDocument/signatureHelp") => { $crate::request::SignatureHelpRequest };
+    ("textDocument/definition") => { $crate::request::DefinitionRequest };
+    ("textDocument/references") => { $crate::request::ReferencesRequest };
+    ("textDocument/documentHighlight") => { $crate::request::DocumentHighlightRequest };
+    ("textDocument/documentSymbol") => { $crate::request::DocumentSymbolRequest };
+    ("textDocument/codeAction") => { $crate::request::CodeActionRequest };
+    ("codeAction/resolve") => { $crate::request::CodeActionResolveRequest };
+    ("workspace/symbol") => { $crate::request::WorkspaceSymbolRequest };
+    ("workspaceSymbol/resolve") => { $crate::request::WorkspaceSymbolResolveRequest };
+    ("textDocument/codeLens") => { $crate::request::CodeLensRequest };
+    ("codeLens/resolve") => { $crate::request::CodeLensResolveRequest };
+    ("workspace/codeLens/refresh") => { $crate::request::CodeLensRefreshRequest };
+    ("textDocument/documentLink") => { $crate::request::DocumentLinkRequest };
+    ("documentLink/resolve") => { $crate::request::DocumentLinkResolveRequest };
+    ("textDocument/formatting") => { $crate::request::DocumentFormattingRequest };
+    ("textDocument/rangeFormatting") => { $crate::request::DocumentRangeFormattingRequest };
+    ("textDocument/rangesFormatting") => { $crate::request::DocumentRangesFormattingRequest };
+    ("textDocument/onTypeFormatting") => { $crate::request::DocumentOnTypeFormattingRequest };
+    ("textDocument/rename") => { $crate::request::RenameRequest };
+    ("textDocument/prepareRename") => { $crate::request::PrepareRenameRequest };
+    ("workspace/executeCommand") => { $crate::request::ExecuteCommandRequest };
+    ("workspace/applyEdit") => { $crate::request::ApplyWorkspaceEditRequest };
 }
+
 
 pub enum ImplementationRequest {}
 impl Request for ImplementationRequest {

--- a/lspt/src/generated/structs.rs
+++ b/lspt/src/generated/structs.rs
@@ -1,8 +1,8 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
-use super::*;
 use crate::{HashMap, Uri};
 use serde::{Deserialize, Serialize};
+use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/lspt/src/generated/structs.rs
+++ b/lspt/src/generated/structs.rs
@@ -1,8 +1,8 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
-use crate::{HashMap, Union2, Union3, Union4, Uri};
-use serde::{Deserialize, Serialize};
 use super::*;
+use crate::{HashMap, Uri};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -543,11 +543,11 @@ pub struct SemanticTokensRegistrationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a specific range
     /// of a document.
-    pub range: Option<Union2<bool, serde_json::Value>>,
+    pub range: Option<SemanticTokensRegistrationOptionsRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a full document.
-    pub full: Option<Union2<bool, SemanticTokensFullDelta>>,
+    pub full: Option<SemanticTokensRegistrationOptionsFull>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The id used to register the request. The id can be used to deregister
@@ -740,7 +740,7 @@ pub struct WorkspaceEdit {
     ///
     /// If a client neither supports `documentChanges` nor `workspace.workspaceEdit.resourceOperations` then
     /// only plain `TextEdit`s using the `changes` property are supported.
-    pub document_changes: Option<Vec<Union4<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>>,
+    pub document_changes: Option<Vec<WorkspaceEditDocumentChangesItem>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A map of change annotations that can be referenced in `AnnotatedTextEdit`s or create, rename and
@@ -1013,7 +1013,7 @@ pub struct InlayHint {
     /// InlayHintLabelPart label parts.
     ///
     /// *Note* that neither the string nor the label part can be empty.
-    pub label: Union2<String, Vec<InlayHintLabelPart>>,
+    pub label: InlayHintLabel,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The kind of this hint. Can be omitted in which case the client
@@ -1030,7 +1030,7 @@ pub struct InlayHint {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The tooltip text when you hover over this item.
-    pub tooltip: Option<Union2<String, MarkupContent>>,
+    pub tooltip: Option<InlayHintTooltip>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Render padding before the hint.
@@ -1109,7 +1109,7 @@ pub struct DocumentDiagnosticParams {
 ///
 /// @since 3.17.0
 pub struct DocumentDiagnosticReportPartialResult {
-    pub related_documents: HashMap<Uri, Union2<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>>,
+    pub related_documents: HashMap<Uri, DocumentDiagnosticReportPartialResultRelatedDocumentsValue>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1215,7 +1215,7 @@ pub struct DidOpenNotebookDocumentParams {
 /// @since 3.17.0
 pub struct NotebookDocumentSyncRegistrationOptions {
     /// The notebooks to be synced
-    pub notebook_selector: Vec<Union2<NotebookDocumentFilterWithNotebook, NotebookDocumentFilterWithCells>>,
+    pub notebook_selector: Vec<NotebookDocumentSyncRegistrationOptionsNotebookSelectorItem>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether save notification should be forwarded to
@@ -1324,7 +1324,7 @@ pub struct InlineCompletionList {
 /// @proposed
 pub struct InlineCompletionItem {
     /// The text to replace the range with. Must be set.
-    pub insert_text: Union2<String, StringValue>,
+    pub insert_text: InlineCompletionItemInsertText,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A text that is used to decide if this inline completion should be shown. When `falsy` the {@link InlineCompletionItem.insertText} is used.
@@ -1518,7 +1518,7 @@ pub struct DidChangeConfigurationParams {
 #[serde(rename_all = "camelCase")]
 pub struct DidChangeConfigurationRegistrationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub section: Option<Union2<String, Vec<String>>>,
+    pub section: Option<DidChangeConfigurationRegistrationOptionsSection>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1766,7 +1766,7 @@ pub struct CompletionItem {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A human-readable string that represents a doc-comment.
-    pub documentation: Option<Union2<String, MarkupContent>>,
+    pub documentation: Option<CompletionItemDocumentation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Select this item when showing.
@@ -1840,7 +1840,7 @@ pub struct CompletionItem {
     /// contained and starting at the same position.
     ///
     /// @since 3.16.0 additional type `InsertReplaceEdit`
-    pub text_edit: Option<Union2<TextEdit, InsertReplaceEdit>>,
+    pub text_edit: Option<CompletionItemTextEdit>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The edit text used if the completion item is part of a CompletionList and
@@ -2000,7 +2000,7 @@ pub struct HoverParams {
 /// The result of a hover request.
 pub struct Hover {
     /// The hover's content
-    pub contents: Union3<MarkupContent, MarkedString, Vec<MarkedString>>,
+    pub contents: HoverContents,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// An optional range inside the text document that is used to
@@ -2539,7 +2539,7 @@ pub struct WorkspaceSymbol {
     /// capability `workspace.symbol.resolveSupport`.
     ///
     /// See SymbolInformation#location for more details.
-    pub location: Union2<Location, LocationUriOnly>,
+    pub location: WorkspaceSymbolLocation,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A data entry field that is preserved on a workspace symbol between a
@@ -3005,7 +3005,7 @@ pub struct LogTraceParams {
 #[serde(rename_all = "camelCase")]
 pub struct CancelParams {
     /// The request id to cancel.
-    pub id: Union2<i32, String>,
+    pub id: CancelParamsId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -3222,11 +3222,11 @@ pub struct SemanticTokensOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a specific range
     /// of a document.
-    pub range: Option<Union2<bool, serde_json::Value>>,
+    pub range: Option<SemanticTokensOptionsRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a full document.
-    pub full: Option<Union2<bool, SemanticTokensFullDelta>>,
+    pub full: Option<SemanticTokensOptionsFull>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_done_progress: Option<bool>,
@@ -3281,7 +3281,7 @@ pub struct TextDocumentEdit {
     ///
     /// @since 3.18.0 - support for SnippetTextEdit. This is guarded using a
     /// client capability.
-    pub edits: Vec<Union2<TextEdit, AnnotatedTextEdit>>,
+    pub edits: Vec<TextDocumentEditEditsItem>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -3512,7 +3512,7 @@ pub struct InlayHintLabelPart {
     /// The tooltip text when you hover over this label part. Depending on
     /// the client capability `inlayHint.resolveSupport` clients might resolve
     /// this property late using the resolve request.
-    pub tooltip: Option<Union2<String, MarkupContent>>,
+    pub tooltip: Option<InlayHintLabelPartTooltip>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// An optional source code location that represents this
@@ -3609,7 +3609,7 @@ pub struct RelatedFullDocumentDiagnosticReport {
     /// a.cpp and result in errors in a header file b.hpp.
     ///
     /// @since 3.17.0
-    pub related_documents: Option<HashMap<Uri, Union2<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>>>,
+    pub related_documents: Option<HashMap<Uri, RelatedFullDocumentDiagnosticReportRelatedDocumentsValue>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3636,7 +3636,7 @@ pub struct RelatedUnchangedDocumentDiagnosticReport {
     /// a.cpp and result in errors in a header file b.hpp.
     ///
     /// @since 3.17.0
-    pub related_documents: Option<HashMap<Uri, Union2<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>>>,
+    pub related_documents: Option<HashMap<Uri, RelatedUnchangedDocumentDiagnosticReportRelatedDocumentsValue>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3777,7 +3777,7 @@ pub struct TextDocumentItem {
 /// @since 3.17.0
 pub struct NotebookDocumentSyncOptions {
     /// The notebooks to be synced
-    pub notebook_selector: Vec<Union2<NotebookDocumentFilterWithNotebook, NotebookDocumentFilterWithCells>>,
+    pub notebook_selector: Vec<NotebookDocumentSyncOptionsNotebookSelectorItem>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether save notification should be forwarded to
@@ -3949,13 +3949,13 @@ pub struct ServerCapabilities {
     /// Defines how text documents are synced. Is either a detailed structure
     /// defining each notification or for backwards compatibility the
     /// TextDocumentSyncKind number.
-    pub text_document_sync: Option<Union2<TextDocumentSyncOptions, TextDocumentSyncKind>>,
+    pub text_document_sync: Option<ServerCapabilitiesTextDocumentSync>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Defines how notebook documents are synced.
     ///
     /// @since 3.17.0
-    pub notebook_document_sync: Option<Union2<NotebookDocumentSyncOptions, NotebookDocumentSyncRegistrationOptions>>,
+    pub notebook_document_sync: Option<ServerCapabilitiesNotebookDocumentSync>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides completion support.
@@ -3963,7 +3963,7 @@ pub struct ServerCapabilities {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides hover support.
-    pub hover_provider: Option<Union2<bool, HoverOptions>>,
+    pub hover_provider: Option<ServerCapabilitiesHoverProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides signature help support.
@@ -3971,37 +3971,37 @@ pub struct ServerCapabilities {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides Goto Declaration support.
-    pub declaration_provider: Option<Union3<bool, DeclarationOptions, DeclarationRegistrationOptions>>,
+    pub declaration_provider: Option<ServerCapabilitiesDeclarationProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides goto definition support.
-    pub definition_provider: Option<Union2<bool, DefinitionOptions>>,
+    pub definition_provider: Option<ServerCapabilitiesDefinitionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides Goto Type Definition support.
-    pub type_definition_provider: Option<Union3<bool, TypeDefinitionOptions, TypeDefinitionRegistrationOptions>>,
+    pub type_definition_provider: Option<ServerCapabilitiesTypeDefinitionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides Goto Implementation support.
-    pub implementation_provider: Option<Union3<bool, ImplementationOptions, ImplementationRegistrationOptions>>,
+    pub implementation_provider: Option<ServerCapabilitiesImplementationProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides find references support.
-    pub references_provider: Option<Union2<bool, ReferenceOptions>>,
+    pub references_provider: Option<ServerCapabilitiesReferencesProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document highlight support.
-    pub document_highlight_provider: Option<Union2<bool, DocumentHighlightOptions>>,
+    pub document_highlight_provider: Option<ServerCapabilitiesDocumentHighlightProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document symbol support.
-    pub document_symbol_provider: Option<Union2<bool, DocumentSymbolOptions>>,
+    pub document_symbol_provider: Option<ServerCapabilitiesDocumentSymbolProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides code actions. CodeActionOptions may only be
     /// specified if the client states that it supports
     /// `codeActionLiteralSupport` in its initial `initialize` request.
-    pub code_action_provider: Option<Union2<bool, CodeActionOptions>>,
+    pub code_action_provider: Option<ServerCapabilitiesCodeActionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides code lens.
@@ -4013,19 +4013,19 @@ pub struct ServerCapabilities {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides color provider support.
-    pub color_provider: Option<Union3<bool, DocumentColorOptions, DocumentColorRegistrationOptions>>,
+    pub color_provider: Option<ServerCapabilitiesColorProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides workspace symbol support.
-    pub workspace_symbol_provider: Option<Union2<bool, WorkspaceSymbolOptions>>,
+    pub workspace_symbol_provider: Option<ServerCapabilitiesWorkspaceSymbolProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document formatting.
-    pub document_formatting_provider: Option<Union2<bool, DocumentFormattingOptions>>,
+    pub document_formatting_provider: Option<ServerCapabilitiesDocumentFormattingProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document range formatting.
-    pub document_range_formatting_provider: Option<Union2<bool, DocumentRangeFormattingOptions>>,
+    pub document_range_formatting_provider: Option<ServerCapabilitiesDocumentRangeFormattingProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document formatting on typing.
@@ -4035,15 +4035,15 @@ pub struct ServerCapabilities {
     /// The server provides rename support. RenameOptions may only be
     /// specified if the client states that it supports
     /// `prepareSupport` in its initial `initialize` request.
-    pub rename_provider: Option<Union2<bool, RenameOptions>>,
+    pub rename_provider: Option<ServerCapabilitiesRenameProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides folding provider support.
-    pub folding_range_provider: Option<Union3<bool, FoldingRangeOptions, FoldingRangeRegistrationOptions>>,
+    pub folding_range_provider: Option<ServerCapabilitiesFoldingRangeProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides selection range support.
-    pub selection_range_provider: Option<Union3<bool, SelectionRangeOptions, SelectionRangeRegistrationOptions>>,
+    pub selection_range_provider: Option<ServerCapabilitiesSelectionRangeProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides execute command support.
@@ -4053,49 +4053,49 @@ pub struct ServerCapabilities {
     /// The server provides call hierarchy support.
     ///
     /// @since 3.16.0
-    pub call_hierarchy_provider: Option<Union3<bool, CallHierarchyOptions, CallHierarchyRegistrationOptions>>,
+    pub call_hierarchy_provider: Option<ServerCapabilitiesCallHierarchyProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides linked editing range support.
     ///
     /// @since 3.16.0
-    pub linked_editing_range_provider: Option<Union3<bool, LinkedEditingRangeOptions, LinkedEditingRangeRegistrationOptions>>,
+    pub linked_editing_range_provider: Option<ServerCapabilitiesLinkedEditingRangeProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides semantic tokens support.
     ///
     /// @since 3.16.0
-    pub semantic_tokens_provider: Option<Union2<SemanticTokensOptions, SemanticTokensRegistrationOptions>>,
+    pub semantic_tokens_provider: Option<ServerCapabilitiesSemanticTokensProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides moniker support.
     ///
     /// @since 3.16.0
-    pub moniker_provider: Option<Union3<bool, MonikerOptions, MonikerRegistrationOptions>>,
+    pub moniker_provider: Option<ServerCapabilitiesMonikerProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides type hierarchy support.
     ///
     /// @since 3.17.0
-    pub type_hierarchy_provider: Option<Union3<bool, TypeHierarchyOptions, TypeHierarchyRegistrationOptions>>,
+    pub type_hierarchy_provider: Option<ServerCapabilitiesTypeHierarchyProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides inline values.
     ///
     /// @since 3.17.0
-    pub inline_value_provider: Option<Union3<bool, InlineValueOptions, InlineValueRegistrationOptions>>,
+    pub inline_value_provider: Option<ServerCapabilitiesInlineValueProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides inlay hints.
     ///
     /// @since 3.17.0
-    pub inlay_hint_provider: Option<Union3<bool, InlayHintOptions, InlayHintRegistrationOptions>>,
+    pub inlay_hint_provider: Option<ServerCapabilitiesInlayHintProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server has support for pull model diagnostics.
     ///
     /// @since 3.17.0
-    pub diagnostic_provider: Option<Union2<DiagnosticOptions, DiagnosticRegistrationOptions>>,
+    pub diagnostic_provider: Option<ServerCapabilitiesDiagnosticProvider>,
 
     #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4103,7 +4103,7 @@ pub struct ServerCapabilities {
     ///
     /// @since 3.18.0
     /// @proposed
-    pub inline_completion_provider: Option<Union2<bool, InlineCompletionOptions>>,
+    pub inline_completion_provider: Option<ServerCapabilitiesInlineCompletionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Workspace specific server capabilities.
@@ -4192,7 +4192,7 @@ pub struct Diagnostic {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The diagnostic's code, which usually appear in the user interface.
-    pub code: Option<Union2<i32, String>>,
+    pub code: Option<DiagnosticCode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// An optional property to describe the error code.
@@ -4303,7 +4303,7 @@ pub struct CompletionItemDefaults {
     /// A default edit range.
     ///
     /// @since 3.17.0
-    pub edit_range: Option<Union2<Range, EditRangeWithInsertReplace>>,
+    pub edit_range: Option<CompletionItemDefaultsEditRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A default insert text format.
@@ -4480,7 +4480,7 @@ pub struct SignatureInformation {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The human-readable doc-comment of this signature. Will be shown
     /// in the UI but can be omitted.
-    pub documentation: Option<Union2<String, MarkupContent>>,
+    pub documentation: Option<SignatureInformationDocumentation>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The parameters of this signature.
@@ -5083,7 +5083,7 @@ pub struct NotebookDocumentFilterWithNotebook {
     /// The notebook to be synced If a string
     /// value is provided it matches against the
     /// notebook type. '*' matches every notebook.
-    pub notebook: Union2<String, NotebookDocumentFilter>,
+    pub notebook: NotebookDocumentFilterWithNotebookNotebook,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The cells of the matching notebook to be synced.
@@ -5098,7 +5098,7 @@ pub struct NotebookDocumentFilterWithCells {
     /// The notebook to be synced If a string
     /// value is provided it matches against the
     /// notebook type. '*' matches every notebook.
-    pub notebook: Option<Union2<String, NotebookDocumentFilter>>,
+    pub notebook: Option<NotebookDocumentFilterWithCellsNotebook>,
 
     /// The cells of the matching notebook to be synced.
     pub cells: Vec<NotebookCellLanguage>,
@@ -5214,7 +5214,7 @@ pub struct TextDocumentSyncOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// If present save notifications are sent to the server. If omitted the notification should not be
     /// sent.
-    pub save: Option<Union2<bool, SaveOptions>>,
+    pub save: Option<TextDocumentSyncOptionsSave>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -5241,7 +5241,7 @@ pub struct WorkspaceOptions {
     ///
     /// @since 3.18.0
     /// @proposed
-    pub text_document_content: Option<Union2<TextDocumentContentOptions, TextDocumentContentRegistrationOptions>>,
+    pub text_document_content: Option<WorkspaceOptionsTextDocumentContent>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -5338,12 +5338,12 @@ pub struct ParameterInformation {
     ///
     /// *Note*: a label of type string should be a substring of its containing signature label.
     /// Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
-    pub label: Union2<String, (u32, u32)>,
+    pub label: ParameterInformationLabel,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The human-readable doc-comment of this parameter. Will be shown
     /// in the UI but can be omitted.
-    pub documentation: Option<Union2<String, MarkupContent>>,
+    pub documentation: Option<ParameterInformationDocumentation>,
 }
 
 #[cfg(feature = "proposed")]
@@ -5378,7 +5378,7 @@ pub struct NotebookCellTextDocumentFilter {
     /// containing the notebook cell. If a string
     /// value is provided it matches against the
     /// notebook type. '*' matches every notebook.
-    pub notebook: Union2<String, NotebookDocumentFilter>,
+    pub notebook: NotebookCellTextDocumentFilterNotebook,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A language id like `python`.
@@ -5821,7 +5821,7 @@ pub struct WorkspaceFoldersServerCapabilities {
     /// under which the notification is registered on the client
     /// side. The ID can be used to unregister for these events
     /// using the `client/unregisterCapability` request.
-    pub change_notifications: Option<Union2<String, bool>>,
+    pub change_notifications: Option<WorkspaceFoldersServerCapabilitiesChangeNotifications>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -5865,7 +5865,7 @@ pub struct FileOperationOptions {
 pub struct RelativePattern {
     /// A workspace folder or a base URI to which this pattern will be matched
     /// against relatively.
-    pub base_uri: Union2<WorkspaceFolder, Uri>,
+    pub base_uri: RelativePatternBaseUri,
 
     /// The actual glob pattern;
     pub pattern: Pattern,
@@ -7327,12 +7327,12 @@ pub struct ClientSemanticTokensRequestOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The client will send the `textDocument/semanticTokens/range` request if
     /// the server provides a corresponding handler.
-    pub range: Option<Union2<bool, serde_json::Value>>,
+    pub range: Option<ClientSemanticTokensRequestOptionsRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The client will send the `textDocument/semanticTokens/full` request if
     /// the server provides a corresponding handler.
-    pub full: Option<Union2<bool, ClientSemanticTokensRequestFullDelta>>,
+    pub full: Option<ClientSemanticTokensRequestOptionsFull>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/lspt/src/generated/structs.rs
+++ b/lspt/src/generated/structs.rs
@@ -1109,7 +1109,7 @@ pub struct DocumentDiagnosticParams {
 ///
 /// @since 3.17.0
 pub struct DocumentDiagnosticReportPartialResult {
-    pub related_documents: HashMap<Uri, DocumentDiagnosticReportPartialResultRelatedDocumentsValue>,
+    pub related_documents: HashMap<Uri, RelatedDocumentDiagnosticReport>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3609,7 +3609,7 @@ pub struct RelatedFullDocumentDiagnosticReport {
     /// a.cpp and result in errors in a header file b.hpp.
     ///
     /// @since 3.17.0
-    pub related_documents: Option<HashMap<Uri, RelatedFullDocumentDiagnosticReportRelatedDocumentsValue>>,
+    pub related_documents: Option<HashMap<Uri, RelatedDocumentDiagnosticReport>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3636,7 +3636,7 @@ pub struct RelatedUnchangedDocumentDiagnosticReport {
     /// a.cpp and result in errors in a header file b.hpp.
     ///
     /// @since 3.17.0
-    pub related_documents: Option<HashMap<Uri, RelatedUnchangedDocumentDiagnosticReportRelatedDocumentsValue>>,
+    pub related_documents: Option<HashMap<Uri, RelatedDocumentDiagnosticReport>>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -3949,13 +3949,13 @@ pub struct ServerCapabilities {
     /// Defines how text documents are synced. Is either a detailed structure
     /// defining each notification or for backwards compatibility the
     /// TextDocumentSyncKind number.
-    pub text_document_sync: Option<ServerCapabilitiesTextDocumentSync>,
+    pub text_document_sync: Option<TextDocumentSync>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Defines how notebook documents are synced.
     ///
     /// @since 3.17.0
-    pub notebook_document_sync: Option<ServerCapabilitiesNotebookDocumentSync>,
+    pub notebook_document_sync: Option<NotebookDocumentSync>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides completion support.
@@ -3963,7 +3963,7 @@ pub struct ServerCapabilities {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides hover support.
-    pub hover_provider: Option<ServerCapabilitiesHoverProvider>,
+    pub hover_provider: Option<HoverProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides signature help support.
@@ -3971,37 +3971,37 @@ pub struct ServerCapabilities {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides Goto Declaration support.
-    pub declaration_provider: Option<ServerCapabilitiesDeclarationProvider>,
+    pub declaration_provider: Option<DeclarationProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides goto definition support.
-    pub definition_provider: Option<ServerCapabilitiesDefinitionProvider>,
+    pub definition_provider: Option<DefinitionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides Goto Type Definition support.
-    pub type_definition_provider: Option<ServerCapabilitiesTypeDefinitionProvider>,
+    pub type_definition_provider: Option<TypeDefinitionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides Goto Implementation support.
-    pub implementation_provider: Option<ServerCapabilitiesImplementationProvider>,
+    pub implementation_provider: Option<ImplementationProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides find references support.
-    pub references_provider: Option<ServerCapabilitiesReferencesProvider>,
+    pub references_provider: Option<ReferencesProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document highlight support.
-    pub document_highlight_provider: Option<ServerCapabilitiesDocumentHighlightProvider>,
+    pub document_highlight_provider: Option<DocumentHighlightProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document symbol support.
-    pub document_symbol_provider: Option<ServerCapabilitiesDocumentSymbolProvider>,
+    pub document_symbol_provider: Option<DocumentSymbolProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides code actions. CodeActionOptions may only be
     /// specified if the client states that it supports
     /// `codeActionLiteralSupport` in its initial `initialize` request.
-    pub code_action_provider: Option<ServerCapabilitiesCodeActionProvider>,
+    pub code_action_provider: Option<CodeActionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides code lens.
@@ -4013,19 +4013,19 @@ pub struct ServerCapabilities {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides color provider support.
-    pub color_provider: Option<ServerCapabilitiesColorProvider>,
+    pub color_provider: Option<ColorProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides workspace symbol support.
-    pub workspace_symbol_provider: Option<ServerCapabilitiesWorkspaceSymbolProvider>,
+    pub workspace_symbol_provider: Option<WorkspaceSymbolProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document formatting.
-    pub document_formatting_provider: Option<ServerCapabilitiesDocumentFormattingProvider>,
+    pub document_formatting_provider: Option<DocumentFormattingProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document range formatting.
-    pub document_range_formatting_provider: Option<ServerCapabilitiesDocumentRangeFormattingProvider>,
+    pub document_range_formatting_provider: Option<DocumentRangeFormattingProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides document formatting on typing.
@@ -4035,15 +4035,15 @@ pub struct ServerCapabilities {
     /// The server provides rename support. RenameOptions may only be
     /// specified if the client states that it supports
     /// `prepareSupport` in its initial `initialize` request.
-    pub rename_provider: Option<ServerCapabilitiesRenameProvider>,
+    pub rename_provider: Option<RenameProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides folding provider support.
-    pub folding_range_provider: Option<ServerCapabilitiesFoldingRangeProvider>,
+    pub folding_range_provider: Option<FoldingRangeProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides selection range support.
-    pub selection_range_provider: Option<ServerCapabilitiesSelectionRangeProvider>,
+    pub selection_range_provider: Option<SelectionRangeProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides execute command support.
@@ -4053,49 +4053,49 @@ pub struct ServerCapabilities {
     /// The server provides call hierarchy support.
     ///
     /// @since 3.16.0
-    pub call_hierarchy_provider: Option<ServerCapabilitiesCallHierarchyProvider>,
+    pub call_hierarchy_provider: Option<CallHierarchyProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides linked editing range support.
     ///
     /// @since 3.16.0
-    pub linked_editing_range_provider: Option<ServerCapabilitiesLinkedEditingRangeProvider>,
+    pub linked_editing_range_provider: Option<LinkedEditingRangeProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides semantic tokens support.
     ///
     /// @since 3.16.0
-    pub semantic_tokens_provider: Option<ServerCapabilitiesSemanticTokensProvider>,
+    pub semantic_tokens_provider: Option<SemanticTokensProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides moniker support.
     ///
     /// @since 3.16.0
-    pub moniker_provider: Option<ServerCapabilitiesMonikerProvider>,
+    pub moniker_provider: Option<MonikerProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides type hierarchy support.
     ///
     /// @since 3.17.0
-    pub type_hierarchy_provider: Option<ServerCapabilitiesTypeHierarchyProvider>,
+    pub type_hierarchy_provider: Option<TypeHierarchyProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides inline values.
     ///
     /// @since 3.17.0
-    pub inline_value_provider: Option<ServerCapabilitiesInlineValueProvider>,
+    pub inline_value_provider: Option<InlineValueProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server provides inlay hints.
     ///
     /// @since 3.17.0
-    pub inlay_hint_provider: Option<ServerCapabilitiesInlayHintProvider>,
+    pub inlay_hint_provider: Option<InlayHintProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The server has support for pull model diagnostics.
     ///
     /// @since 3.17.0
-    pub diagnostic_provider: Option<ServerCapabilitiesDiagnosticProvider>,
+    pub diagnostic_provider: Option<DiagnosticProvider>,
 
     #[cfg(feature = "proposed")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4103,7 +4103,7 @@ pub struct ServerCapabilities {
     ///
     /// @since 3.18.0
     /// @proposed
-    pub inline_completion_provider: Option<ServerCapabilitiesInlineCompletionProvider>,
+    pub inline_completion_provider: Option<InlineCompletionProvider>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Workspace specific server capabilities.

--- a/lspt/src/generated/structs.rs
+++ b/lspt/src/generated/structs.rs
@@ -543,11 +543,11 @@ pub struct SemanticTokensRegistrationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a specific range
     /// of a document.
-    pub range: Option<SemanticTokensRegistrationOptionsRange>,
+    pub range: Option<SemanticTokensRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a full document.
-    pub full: Option<SemanticTokensRegistrationOptionsFull>,
+    pub full: Option<SemanticTokensFull>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The id used to register the request. The id can be used to deregister
@@ -1215,7 +1215,7 @@ pub struct DidOpenNotebookDocumentParams {
 /// @since 3.17.0
 pub struct NotebookDocumentSyncRegistrationOptions {
     /// The notebooks to be synced
-    pub notebook_selector: Vec<NotebookDocumentSyncRegistrationOptionsNotebookSelectorItem>,
+    pub notebook_selector: Vec<NotebookSelectorItem>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether save notification should be forwarded to
@@ -1518,7 +1518,7 @@ pub struct DidChangeConfigurationParams {
 #[serde(rename_all = "camelCase")]
 pub struct DidChangeConfigurationRegistrationOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub section: Option<DidChangeConfigurationRegistrationOptionsSection>,
+    pub section: Option<DidChangeConfigurationSection>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -3222,11 +3222,11 @@ pub struct SemanticTokensOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a specific range
     /// of a document.
-    pub range: Option<SemanticTokensOptionsRange>,
+    pub range: Option<SemanticTokensRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Server supports providing semantic tokens for a full document.
-    pub full: Option<SemanticTokensOptionsFull>,
+    pub full: Option<SemanticTokensFull>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_done_progress: Option<bool>,
@@ -3777,7 +3777,7 @@ pub struct TextDocumentItem {
 /// @since 3.17.0
 pub struct NotebookDocumentSyncOptions {
     /// The notebooks to be synced
-    pub notebook_selector: Vec<NotebookDocumentSyncOptionsNotebookSelectorItem>,
+    pub notebook_selector: Vec<NotebookSelectorItem>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether save notification should be forwarded to
@@ -5083,7 +5083,7 @@ pub struct NotebookDocumentFilterWithNotebook {
     /// The notebook to be synced If a string
     /// value is provided it matches against the
     /// notebook type. '*' matches every notebook.
-    pub notebook: NotebookDocumentFilterWithNotebookNotebook,
+    pub notebook: NotebookDocumentFilterNotebook,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The cells of the matching notebook to be synced.
@@ -5098,7 +5098,7 @@ pub struct NotebookDocumentFilterWithCells {
     /// The notebook to be synced If a string
     /// value is provided it matches against the
     /// notebook type. '*' matches every notebook.
-    pub notebook: Option<NotebookDocumentFilterWithCellsNotebook>,
+    pub notebook: Option<NotebookDocumentFilterNotebook>,
 
     /// The cells of the matching notebook to be synced.
     pub cells: Vec<NotebookCellLanguage>,
@@ -5214,7 +5214,7 @@ pub struct TextDocumentSyncOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// If present save notifications are sent to the server. If omitted the notification should not be
     /// sent.
-    pub save: Option<TextDocumentSyncOptionsSave>,
+    pub save: Option<TextDocumentSyncSave>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -5241,7 +5241,7 @@ pub struct WorkspaceOptions {
     ///
     /// @since 3.18.0
     /// @proposed
-    pub text_document_content: Option<WorkspaceOptionsTextDocumentContent>,
+    pub text_document_content: Option<WorkspaceTextDocumentContent>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -5378,7 +5378,7 @@ pub struct NotebookCellTextDocumentFilter {
     /// containing the notebook cell. If a string
     /// value is provided it matches against the
     /// notebook type. '*' matches every notebook.
-    pub notebook: NotebookCellTextDocumentFilterNotebook,
+    pub notebook: NotebookDocumentFilterNotebook,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// A language id like `python`.
@@ -5821,7 +5821,7 @@ pub struct WorkspaceFoldersServerCapabilities {
     /// under which the notification is registered on the client
     /// side. The ID can be used to unregister for these events
     /// using the `client/unregisterCapability` request.
-    pub change_notifications: Option<WorkspaceFoldersServerCapabilitiesChangeNotifications>,
+    pub change_notifications: Option<WorkspaceFoldersChangeNotifications>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -7327,12 +7327,12 @@ pub struct ClientSemanticTokensRequestOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The client will send the `textDocument/semanticTokens/range` request if
     /// the server provides a corresponding handler.
-    pub range: Option<ClientSemanticTokensRequestOptionsRange>,
+    pub range: Option<ClientSemanticTokensRequestRange>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The client will send the `textDocument/semanticTokens/full` request if
     /// the server provides a corresponding handler.
-    pub full: Option<ClientSemanticTokensRequestOptionsFull>,
+    pub full: Option<ClientSemanticTokensRequestFull>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/lspt/src/generated/type_aliases.rs
+++ b/lspt/src/generated/type_aliases.rs
@@ -1,24 +1,12 @@
 // DO NOT EDIT THIS GENERATED FILE.
 
 use super::*;
-use crate::{Union2, Union3};
-
-/// The definition of a symbol represented as one or many {@link Location locations}.
-/// For most programming languages there is only one location at which a symbol is
-/// defined.
-///
-/// Servers should prefer returning `DefinitionLink` over `Definition` if supported
-/// by the client.
-pub type Definition = Union2<Location, Vec<Location>>;
 
 /// Information about where a symbol is defined.
 ///
 /// Provides additional metadata over normal {@link Location location} definitions, including the range of
 /// the defining symbol
 pub type DefinitionLink = LocationLink;
-
-/// The declaration of a symbol representation as one or many {@link Location locations}.
-pub type Declaration = Union2<Location, Vec<Location>>;
 
 /// Information about where a symbol is declared.
 ///
@@ -29,26 +17,6 @@ pub type Declaration = Union2<Location, Vec<Location>>;
 /// by the client.
 pub type DeclarationLink = LocationLink;
 
-/// Inline value information can be provided by different means:
-/// - directly as a text value (class InlineValueText).
-/// - as a name to use for a variable lookup (class InlineValueVariableLookup)
-/// - as an evaluatable expression (class InlineValueEvaluatableExpression)
-/// The InlineValue types combines all inline value types into one type.
-///
-/// @since 3.17.0
-pub type InlineValue = Union3<InlineValueText, InlineValueVariableLookup, InlineValueEvaluatableExpression>;
-
-/// The result of a document diagnostic pull request. A report can
-/// either be a full report containing all diagnostics for the
-/// requested document or an unchanged report indicating that nothing
-/// has changed in terms of diagnostics in comparison to the last
-/// pull request.
-///
-/// @since 3.17.0
-pub type DocumentDiagnosticReport = Union2<RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport>;
-
-pub type PrepareRenameResult = Union3<Range, PrepareRenamePlaceholder, PrepareRenameDefaultBehavior>;
-
 /// A document selector is the combination of one or many document filters.
 ///
 /// @sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;
@@ -56,69 +24,8 @@ pub type PrepareRenameResult = Union3<Range, PrepareRenamePlaceholder, PrepareRe
 /// The use of a string as a document filter is deprecated @since 3.16.0.
 pub type DocumentSelector = Vec<DocumentFilter>;
 
-pub type ProgressToken = Union2<i32, String>;
-
 /// An identifier to refer to a change annotation stored with a workspace edit.
 pub type ChangeAnnotationIdentifier = String;
-
-/// A workspace diagnostic document report.
-///
-/// @since 3.17.0
-pub type WorkspaceDocumentDiagnosticReport = Union2<WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport>;
-
-/// An event describing a change to a text document. If only a text is provided
-/// it is considered to be the full content of the document.
-pub type TextDocumentContentChangeEvent = Union2<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>;
-
-/// MarkedString can be used to render human readable text. It is either a markdown string
-/// or a code-block that provides a language and a code snippet. The language identifier
-/// is semantically equal to the optional language identifier in fenced code blocks in GitHub
-/// issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
-///
-/// The pair of a language and a value is an equivalent to markdown:
-/// ```${language}
-/// ${value}
-/// ```
-///
-/// Note that markdown strings will be sanitized - that means html will be escaped.
-/// @deprecated use MarkupContent instead.
-pub type MarkedString = Union2<String, MarkedStringWithLanguage>;
-
-/// A document filter describes a top level text document or
-/// a notebook cell document.
-///
-/// @since 3.17.0 - support for NotebookCellTextDocumentFilter.
-pub type DocumentFilter = Union2<TextDocumentFilter, NotebookCellTextDocumentFilter>;
-
-/// The glob pattern. Either a string pattern or a relative pattern.
-///
-/// @since 3.17.0
-pub type GlobPattern = Union2<Pattern, RelativePattern>;
-
-/// A document filter denotes a document by different properties like
-/// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
-/// its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
-///
-/// Glob patterns can have the following syntax:
-/// - `*` to match one or more characters in a path segment
-/// - `?` to match on one character in a path segment
-/// - `**` to match any number of path segments, including none
-/// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
-/// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
-/// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
-///
-/// @sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`
-/// @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
-///
-/// @since 3.17.0
-pub type TextDocumentFilter = Union3<TextDocumentFilterLanguage, TextDocumentFilterScheme, TextDocumentFilterPattern>;
-
-/// A notebook document filter denotes a notebook document by
-/// different properties. The properties will be match
-/// against the notebook's URI (same as with documents)
-///
-/// @since 3.17.0
-pub type NotebookDocumentFilter = Union3<NotebookDocumentFilterNotebookType, NotebookDocumentFilterScheme, NotebookDocumentFilterPattern>;
 
 /// The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:
 /// - `*` to match one or more characters in a path segment

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -963,6 +963,8 @@ pub type CancelParamsId = NumberOrString;
 pub enum TextDocumentEditEditsItem {
     TextEdit(TextEdit),
     AnnotatedTextEdit(AnnotatedTextEdit),
+    #[cfg(feature = "proposed")]
+    SnippetTextEdit(SnippetTextEdit),
 }
 
 impl From<TextEdit> for TextDocumentEditEditsItem {
@@ -974,6 +976,13 @@ impl From<TextEdit> for TextDocumentEditEditsItem {
 impl From<AnnotatedTextEdit> for TextDocumentEditEditsItem {
     fn from(value: AnnotatedTextEdit) -> Self {
         Self::AnnotatedTextEdit(value)
+    }
+}
+
+#[cfg(feature = "proposed")]
+impl From<SnippetTextEdit> for TextDocumentEditEditsItem {
+    fn from(value: SnippetTextEdit) -> Self {
+        Self::SnippetTextEdit(value)
     }
 }
 

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -152,22 +152,24 @@ impl From<PrepareRenameDefaultBehavior> for PrepareRenameResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ProgressToken {
+pub enum NumberOrString {
     Integer(i32),
     String(String),
 }
 
-impl From<i32> for ProgressToken {
+impl From<i32> for NumberOrString {
     fn from(value: i32) -> Self {
         Self::Integer(value)
     }
 }
 
-impl From<String> for ProgressToken {
+impl From<String> for NumberOrString {
     fn from(value: String) -> Self {
         Self::String(value)
     }
 }
+
+pub type ProgressToken = NumberOrString;
 
 
 /// A workspace diagnostic document report.
@@ -964,24 +966,7 @@ impl From<LocationUriOnly> for WorkspaceSymbolLocation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CancelParamsId {
-    Integer(i32),
-    String(String),
-}
-
-impl From<i32> for CancelParamsId {
-    fn from(value: i32) -> Self {
-        Self::Integer(value)
-    }
-}
-
-impl From<String> for CancelParamsId {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
+pub type CancelParamsId = NumberOrString;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1646,24 +1631,7 @@ impl From<InlineCompletionOptions> for InlineCompletionProvider {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum DiagnosticCode {
-    Integer(i32),
-    String(String),
-}
-
-impl From<i32> for DiagnosticCode {
-    fn from(value: i32) -> Self {
-        Self::Integer(value)
-    }
-}
-
-impl From<String> for DiagnosticCode {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
+pub type DiagnosticCode = NumberOrString;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -317,17 +317,17 @@ pub enum WorkspaceSymbolResponse {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum SemanticTokensRegistrationOptionsRange {
+pub enum SemanticTokensRange {
     Boolean(bool),
     Object(serde_json::Value),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum SemanticTokensRegistrationOptionsFull {
+pub enum SemanticTokensFull {
     Boolean(bool),
     /// `SemanticTokensFullDelta`.
-    FullDelta(SemanticTokensFullDelta),
+    Delta(SemanticTokensFullDelta),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -365,7 +365,7 @@ pub enum RelatedDocumentDiagnosticReport {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum NotebookDocumentSyncRegistrationOptionsNotebookSelectorItem {
+pub enum NotebookSelectorItem {
     /// `NotebookDocumentFilterWithNotebook`.
     Notebook(NotebookDocumentFilterWithNotebook),
     /// `NotebookDocumentFilterWithCells`.
@@ -382,7 +382,7 @@ pub enum InlineCompletionItemInsertText {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum DidChangeConfigurationRegistrationOptionsSection {
+pub enum DidChangeConfigurationSection {
     String(String),
     StringList(Vec<String>),
 }
@@ -426,21 +426,6 @@ pub enum CancelParamsId {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum SemanticTokensOptionsRange {
-    Boolean(bool),
-    Object(serde_json::Value),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum SemanticTokensOptionsFull {
-    Boolean(bool),
-    /// `SemanticTokensFullDelta`.
-    FullDelta(SemanticTokensFullDelta),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum TextDocumentEditEditsItem {
     TextEdit(TextEdit),
     AnnotatedTextEdit(AnnotatedTextEdit),
@@ -451,15 +436,6 @@ pub enum TextDocumentEditEditsItem {
 pub enum InlayHintLabelPartTooltip {
     String(String),
     MarkupContent(MarkupContent),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum NotebookDocumentSyncOptionsNotebookSelectorItem {
-    /// `NotebookDocumentFilterWithNotebook`.
-    Notebook(NotebookDocumentFilterWithNotebook),
-    /// `NotebookDocumentFilterWithCells`.
-    Cells(NotebookDocumentFilterWithCells),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -729,21 +705,14 @@ pub enum SignatureInformationDocumentation {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum NotebookDocumentFilterWithNotebookNotebook {
+pub enum NotebookDocumentFilterNotebook {
     String(String),
     NotebookDocumentFilter(NotebookDocumentFilter),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum NotebookDocumentFilterWithCellsNotebook {
-    String(String),
-    NotebookDocumentFilter(NotebookDocumentFilter),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum TextDocumentSyncOptionsSave {
+pub enum TextDocumentSyncSave {
     Boolean(bool),
     SaveOptions(SaveOptions),
 }
@@ -751,7 +720,7 @@ pub enum TextDocumentSyncOptionsSave {
 #[cfg(feature = "proposed")]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum WorkspaceOptionsTextDocumentContent {
+pub enum WorkspaceTextDocumentContent {
     /// `TextDocumentContentOptions`.
     Options(TextDocumentContentOptions),
     /// `TextDocumentContentRegistrationOptions`.
@@ -774,15 +743,7 @@ pub enum ParameterInformationDocumentation {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum NotebookCellTextDocumentFilterNotebook {
-    String(String),
-    /// `NotebookDocumentFilter`.
-    DocumentFilter(NotebookDocumentFilter),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum WorkspaceFoldersServerCapabilitiesChangeNotifications {
+pub enum WorkspaceFoldersChangeNotifications {
     String(String),
     Boolean(bool),
 }
@@ -796,15 +757,15 @@ pub enum RelativePatternBaseUri {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ClientSemanticTokensRequestOptionsRange {
+pub enum ClientSemanticTokensRequestRange {
     Boolean(bool),
     Object(serde_json::Value),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ClientSemanticTokensRequestOptionsFull {
+pub enum ClientSemanticTokensRequestFull {
     Boolean(bool),
     /// `ClientSemanticTokensRequestFullDelta`.
-    FullDelta(ClientSemanticTokensRequestFullDelta),
+    Delta(ClientSemanticTokensRequestFullDelta),
 }

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -10,14 +10,14 @@ use crate::{HashMap, Uri};
 use serde::{Deserialize, Serialize};
 use super::*;
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// The definition of a symbol represented as one or many {@link Location locations}.
 /// For most programming languages there is only one location at which a symbol is
 /// defined.
 ///
 /// Servers should prefer returning `DefinitionLink` over `Definition` if supported
 /// by the client.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum Definition {
     Location(Location),
     /// `LocationList`.
@@ -36,10 +36,9 @@ impl From<Vec<Location>> for Definition {
     }
 }
 
-
-/// The declaration of a symbol representation as one or many {@link Location locations}.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
+/// The declaration of a symbol representation as one or many {@link Location locations}.
 pub enum Declaration {
     Location(Location),
     /// `LocationList`.
@@ -58,7 +57,8 @@ impl From<Vec<Location>> for Declaration {
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// Inline value information can be provided by different means:
 /// - directly as a text value (class InlineValueText).
 /// - as a name to use for a variable lookup (class InlineValueVariableLookup)
@@ -66,8 +66,6 @@ impl From<Vec<Location>> for Declaration {
 /// The InlineValue types combines all inline value types into one type.
 ///
 /// @since 3.17.0
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum InlineValue {
     /// `InlineValueText`.
     Text(InlineValueText),
@@ -95,7 +93,8 @@ impl From<InlineValueEvaluatableExpression> for InlineValue {
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// The result of a document diagnostic pull request. A report can
 /// either be a full report containing all diagnostics for the
 /// requested document or an unchanged report indicating that nothing
@@ -103,8 +102,6 @@ impl From<InlineValueEvaluatableExpression> for InlineValue {
 /// pull request.
 ///
 /// @since 3.17.0
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum DocumentDiagnosticReport {
     /// `RelatedFullDocumentDiagnosticReport`.
     Full(RelatedFullDocumentDiagnosticReport),
@@ -171,12 +168,11 @@ impl From<String> for NumberOrString {
 
 pub type ProgressToken = NumberOrString;
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// A workspace diagnostic document report.
 ///
 /// @since 3.17.0
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum WorkspaceDocumentDiagnosticReport {
     /// `WorkspaceFullDocumentDiagnosticReport`.
     Full(WorkspaceFullDocumentDiagnosticReport),
@@ -196,11 +192,10 @@ impl From<WorkspaceUnchangedDocumentDiagnosticReport> for WorkspaceDocumentDiagn
     }
 }
 
-
-/// An event describing a change to a text document. If only a text is provided
-/// it is considered to be the full content of the document.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
+/// An event describing a change to a text document. If only a text is provided
+/// it is considered to be the full content of the document.
 pub enum TextDocumentContentChangeEvent {
     /// `TextDocumentContentChangePartial`.
     Partial(TextDocumentContentChangePartial),
@@ -220,7 +215,8 @@ impl From<TextDocumentContentChangeWholeDocument> for TextDocumentContentChangeE
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// MarkedString can be used to render human readable text. It is either a markdown string
 /// or a code-block that provides a language and a code snippet. The language identifier
 /// is semantically equal to the optional language identifier in fenced code blocks in GitHub
@@ -233,8 +229,6 @@ impl From<TextDocumentContentChangeWholeDocument> for TextDocumentContentChangeE
 ///
 /// Note that markdown strings will be sanitized - that means html will be escaped.
 /// @deprecated use MarkupContent instead.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum MarkedString {
     String(String),
     /// `MarkedStringWithLanguage`.
@@ -253,13 +247,12 @@ impl From<MarkedStringWithLanguage> for MarkedString {
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// A document filter describes a top level text document or
 /// a notebook cell document.
 ///
 /// @since 3.17.0 - support for NotebookCellTextDocumentFilter.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum DocumentFilter {
     TextDocumentFilter(TextDocumentFilter),
     NotebookCellTextDocumentFilter(NotebookCellTextDocumentFilter),
@@ -277,12 +270,11 @@ impl From<NotebookCellTextDocumentFilter> for DocumentFilter {
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// The glob pattern. Either a string pattern or a relative pattern.
 ///
 /// @since 3.17.0
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum GlobPattern {
     Pattern(Pattern),
     RelativePattern(RelativePattern),
@@ -300,7 +292,8 @@ impl From<RelativePattern> for GlobPattern {
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// A document filter denotes a document by different properties like
 /// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
 /// its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
@@ -317,8 +310,6 @@ impl From<RelativePattern> for GlobPattern {
 /// @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
 ///
 /// @since 3.17.0
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum TextDocumentFilter {
     /// `TextDocumentFilterLanguage`.
     Language(TextDocumentFilterLanguage),
@@ -346,14 +337,13 @@ impl From<TextDocumentFilterPattern> for TextDocumentFilter {
     }
 }
 
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 /// A notebook document filter denotes a notebook document by
 /// different properties. The properties will be match
 /// against the notebook's URI (same as with documents)
 ///
 /// @since 3.17.0
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum NotebookDocumentFilter {
     /// `NotebookDocumentFilterNotebookType`.
     NotebookType(NotebookDocumentFilterNotebookType),

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -20,7 +20,8 @@ use super::*;
 #[serde(untagged)]
 pub enum Definition {
     Location(Location),
-    LocationList(Vec<Location>),
+    /// `LocationList`.
+    List(Vec<Location>),
 }
 
 
@@ -29,7 +30,8 @@ pub enum Definition {
 #[serde(untagged)]
 pub enum Declaration {
     Location(Location),
-    LocationList(Vec<Location>),
+    /// `LocationList`.
+    List(Vec<Location>),
 }
 
 
@@ -125,7 +127,8 @@ pub enum TextDocumentContentChangeEvent {
 #[serde(untagged)]
 pub enum MarkedString {
     String(String),
-    MarkedStringWithLanguage(MarkedStringWithLanguage),
+    /// `MarkedStringWithLanguage`.
+    WithLanguage(MarkedStringWithLanguage),
 }
 
 
@@ -224,37 +227,44 @@ pub enum DeclarationResponse {
 #[serde(untagged)]
 pub enum SemanticTokensResponse {
     SemanticTokens(SemanticTokens),
-    SemanticTokensPartialResult(SemanticTokensPartialResult),
+    /// `SemanticTokensPartialResult`.
+    PartialResult(SemanticTokensPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensDeltaResponse {
     SemanticTokens(SemanticTokens),
-    SemanticTokensDelta(SemanticTokensDelta),
-    SemanticTokensPartialResult(SemanticTokensPartialResult),
-    SemanticTokensDeltaPartialResult(SemanticTokensDeltaPartialResult),
+    /// `SemanticTokensDelta`.
+    Delta(SemanticTokensDelta),
+    /// `SemanticTokensPartialResult`.
+    PartialResult(SemanticTokensPartialResult),
+    /// `SemanticTokensDeltaPartialResult`.
+    DeltaPartialResult(SemanticTokensDeltaPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensRangeResponse {
     SemanticTokens(SemanticTokens),
-    SemanticTokensPartialResult(SemanticTokensPartialResult),
+    /// `SemanticTokensPartialResult`.
+    PartialResult(SemanticTokensPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentDiagnosticResponse {
     DocumentDiagnosticReport(DocumentDiagnosticReport),
-    DocumentDiagnosticReportPartialResult(DocumentDiagnosticReportPartialResult),
+    /// `DocumentDiagnosticReportPartialResult`.
+    PartialResult(DocumentDiagnosticReportPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceDiagnosticResponse {
     WorkspaceDiagnosticReport(WorkspaceDiagnosticReport),
-    WorkspaceDiagnosticReportPartialResult(WorkspaceDiagnosticReportPartialResult),
+    /// `WorkspaceDiagnosticReportPartialResult`.
+    PartialResult(WorkspaceDiagnosticReportPartialResult),
 }
 
 #[cfg(feature = "proposed")]
@@ -316,7 +326,8 @@ pub enum SemanticTokensRegistrationOptionsRange {
 #[serde(untagged)]
 pub enum SemanticTokensRegistrationOptionsFull {
     Boolean(bool),
-    SemanticTokensFullDelta(SemanticTokensFullDelta),
+    /// `SemanticTokensFullDelta`.
+    FullDelta(SemanticTokensFullDelta),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -332,7 +343,8 @@ pub enum WorkspaceEditDocumentChangesItem {
 #[serde(untagged)]
 pub enum InlayHintLabel {
     String(String),
-    InlayHintLabelPartList(Vec<InlayHintLabelPart>),
+    /// `InlayHintLabelPartList`.
+    PartList(Vec<InlayHintLabelPart>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -344,9 +356,11 @@ pub enum InlayHintTooltip {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum DocumentDiagnosticReportPartialResultRelatedDocumentsValue {
-    FullDocumentDiagnosticReport(FullDocumentDiagnosticReport),
-    UnchangedDocumentDiagnosticReport(UnchangedDocumentDiagnosticReport),
+pub enum RelatedDocumentDiagnosticReport {
+    /// `FullDocumentDiagnosticReport`.
+    Full(FullDocumentDiagnosticReport),
+    /// `UnchangedDocumentDiagnosticReport`.
+    Unchanged(UnchangedDocumentDiagnosticReport),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -399,7 +413,8 @@ pub enum HoverContents {
 #[serde(untagged)]
 pub enum WorkspaceSymbolLocation {
     Location(Location),
-    LocationUriOnly(LocationUriOnly),
+    /// `LocationUriOnly`.
+    UriOnly(LocationUriOnly),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -420,7 +435,8 @@ pub enum SemanticTokensOptionsRange {
 #[serde(untagged)]
 pub enum SemanticTokensOptionsFull {
     Boolean(bool),
-    SemanticTokensFullDelta(SemanticTokensFullDelta),
+    /// `SemanticTokensFullDelta`.
+    FullDelta(SemanticTokensFullDelta),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -439,20 +455,6 @@ pub enum InlayHintLabelPartTooltip {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum RelatedFullDocumentDiagnosticReportRelatedDocumentsValue {
-    FullDocumentDiagnosticReport(FullDocumentDiagnosticReport),
-    UnchangedDocumentDiagnosticReport(UnchangedDocumentDiagnosticReport),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum RelatedUnchangedDocumentDiagnosticReportRelatedDocumentsValue {
-    FullDocumentDiagnosticReport(FullDocumentDiagnosticReport),
-    UnchangedDocumentDiagnosticReport(UnchangedDocumentDiagnosticReport),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum NotebookDocumentSyncOptionsNotebookSelectorItem {
     /// `NotebookDocumentFilterWithNotebook`.
     Notebook(NotebookDocumentFilterWithNotebook),
@@ -462,7 +464,7 @@ pub enum NotebookDocumentSyncOptionsNotebookSelectorItem {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesTextDocumentSync {
+pub enum TextDocumentSync {
     /// `TextDocumentSyncOptions`.
     Options(TextDocumentSyncOptions),
     /// `TextDocumentSyncKind`.
@@ -471,7 +473,7 @@ pub enum ServerCapabilitiesTextDocumentSync {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesNotebookDocumentSync {
+pub enum NotebookDocumentSync {
     /// `NotebookDocumentSyncOptions`.
     Options(NotebookDocumentSyncOptions),
     /// `NotebookDocumentSyncRegistrationOptions`.
@@ -480,14 +482,15 @@ pub enum ServerCapabilitiesNotebookDocumentSync {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesHoverProvider {
+pub enum HoverProvider {
     Boolean(bool),
-    HoverOptions(HoverOptions),
+    /// `HoverOptions`.
+    Options(HoverOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDeclarationProvider {
+pub enum DeclarationProvider {
     Boolean(bool),
     /// `DeclarationOptions`.
     Options(DeclarationOptions),
@@ -497,14 +500,15 @@ pub enum ServerCapabilitiesDeclarationProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDefinitionProvider {
+pub enum DefinitionProvider {
     Boolean(bool),
-    DefinitionOptions(DefinitionOptions),
+    /// `DefinitionOptions`.
+    Options(DefinitionOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesTypeDefinitionProvider {
+pub enum TypeDefinitionProvider {
     Boolean(bool),
     /// `TypeDefinitionOptions`.
     Options(TypeDefinitionOptions),
@@ -514,7 +518,7 @@ pub enum ServerCapabilitiesTypeDefinitionProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesImplementationProvider {
+pub enum ImplementationProvider {
     Boolean(bool),
     /// `ImplementationOptions`.
     Options(ImplementationOptions),
@@ -524,35 +528,38 @@ pub enum ServerCapabilitiesImplementationProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesReferencesProvider {
+pub enum ReferencesProvider {
     Boolean(bool),
     ReferenceOptions(ReferenceOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDocumentHighlightProvider {
+pub enum DocumentHighlightProvider {
     Boolean(bool),
-    DocumentHighlightOptions(DocumentHighlightOptions),
+    /// `DocumentHighlightOptions`.
+    Options(DocumentHighlightOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDocumentSymbolProvider {
+pub enum DocumentSymbolProvider {
     Boolean(bool),
-    DocumentSymbolOptions(DocumentSymbolOptions),
+    /// `DocumentSymbolOptions`.
+    Options(DocumentSymbolOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesCodeActionProvider {
+pub enum CodeActionProvider {
     Boolean(bool),
-    CodeActionOptions(CodeActionOptions),
+    /// `CodeActionOptions`.
+    Options(CodeActionOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesColorProvider {
+pub enum ColorProvider {
     Boolean(bool),
     /// `DocumentColorOptions`.
     Options(DocumentColorOptions),
@@ -562,35 +569,39 @@ pub enum ServerCapabilitiesColorProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesWorkspaceSymbolProvider {
+pub enum WorkspaceSymbolProvider {
     Boolean(bool),
-    WorkspaceSymbolOptions(WorkspaceSymbolOptions),
+    /// `WorkspaceSymbolOptions`.
+    Options(WorkspaceSymbolOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDocumentFormattingProvider {
+pub enum DocumentFormattingProvider {
     Boolean(bool),
-    DocumentFormattingOptions(DocumentFormattingOptions),
+    /// `DocumentFormattingOptions`.
+    Options(DocumentFormattingOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDocumentRangeFormattingProvider {
+pub enum DocumentRangeFormattingProvider {
     Boolean(bool),
-    DocumentRangeFormattingOptions(DocumentRangeFormattingOptions),
+    /// `DocumentRangeFormattingOptions`.
+    Options(DocumentRangeFormattingOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesRenameProvider {
+pub enum RenameProvider {
     Boolean(bool),
-    RenameOptions(RenameOptions),
+    /// `RenameOptions`.
+    Options(RenameOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesFoldingRangeProvider {
+pub enum FoldingRangeProvider {
     Boolean(bool),
     /// `FoldingRangeOptions`.
     Options(FoldingRangeOptions),
@@ -600,7 +611,7 @@ pub enum ServerCapabilitiesFoldingRangeProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesSelectionRangeProvider {
+pub enum SelectionRangeProvider {
     Boolean(bool),
     /// `SelectionRangeOptions`.
     Options(SelectionRangeOptions),
@@ -610,7 +621,7 @@ pub enum ServerCapabilitiesSelectionRangeProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesCallHierarchyProvider {
+pub enum CallHierarchyProvider {
     Boolean(bool),
     /// `CallHierarchyOptions`.
     Options(CallHierarchyOptions),
@@ -620,7 +631,7 @@ pub enum ServerCapabilitiesCallHierarchyProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesLinkedEditingRangeProvider {
+pub enum LinkedEditingRangeProvider {
     Boolean(bool),
     /// `LinkedEditingRangeOptions`.
     Options(LinkedEditingRangeOptions),
@@ -630,7 +641,7 @@ pub enum ServerCapabilitiesLinkedEditingRangeProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesSemanticTokensProvider {
+pub enum SemanticTokensProvider {
     /// `SemanticTokensOptions`.
     Options(SemanticTokensOptions),
     /// `SemanticTokensRegistrationOptions`.
@@ -639,7 +650,7 @@ pub enum ServerCapabilitiesSemanticTokensProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesMonikerProvider {
+pub enum MonikerProvider {
     Boolean(bool),
     /// `MonikerOptions`.
     Options(MonikerOptions),
@@ -649,7 +660,7 @@ pub enum ServerCapabilitiesMonikerProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesTypeHierarchyProvider {
+pub enum TypeHierarchyProvider {
     Boolean(bool),
     /// `TypeHierarchyOptions`.
     Options(TypeHierarchyOptions),
@@ -659,7 +670,7 @@ pub enum ServerCapabilitiesTypeHierarchyProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesInlineValueProvider {
+pub enum InlineValueProvider {
     Boolean(bool),
     /// `InlineValueOptions`.
     Options(InlineValueOptions),
@@ -669,7 +680,7 @@ pub enum ServerCapabilitiesInlineValueProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesInlayHintProvider {
+pub enum InlayHintProvider {
     Boolean(bool),
     /// `InlayHintOptions`.
     Options(InlayHintOptions),
@@ -679,7 +690,7 @@ pub enum ServerCapabilitiesInlayHintProvider {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesDiagnosticProvider {
+pub enum DiagnosticProvider {
     /// `DiagnosticOptions`.
     Options(DiagnosticOptions),
     /// `DiagnosticRegistrationOptions`.
@@ -689,9 +700,10 @@ pub enum ServerCapabilitiesDiagnosticProvider {
 #[cfg(feature = "proposed")]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ServerCapabilitiesInlineCompletionProvider {
+pub enum InlineCompletionProvider {
     Boolean(bool),
-    InlineCompletionOptions(InlineCompletionOptions),
+    /// `InlineCompletionOptions`.
+    Options(InlineCompletionOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -764,7 +776,8 @@ pub enum ParameterInformationDocumentation {
 #[serde(untagged)]
 pub enum NotebookCellTextDocumentFilterNotebook {
     String(String),
-    NotebookDocumentFilter(NotebookDocumentFilter),
+    /// `NotebookDocumentFilter`.
+    DocumentFilter(NotebookDocumentFilter),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -792,5 +805,6 @@ pub enum ClientSemanticTokensRequestOptionsRange {
 #[serde(untagged)]
 pub enum ClientSemanticTokensRequestOptionsFull {
     Boolean(bool),
-    ClientSemanticTokensRequestFullDelta(ClientSemanticTokensRequestFullDelta),
+    /// `ClientSemanticTokensRequestFullDelta`.
+    FullDelta(ClientSemanticTokensRequestFullDelta),
 }

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -24,6 +24,18 @@ pub enum Definition {
     List(Vec<Location>),
 }
 
+impl From<Location> for Definition {
+    fn from(value: Location) -> Self {
+        Self::Location(value)
+    }
+}
+
+impl From<Vec<Location>> for Definition {
+    fn from(value: Vec<Location>) -> Self {
+        Self::List(value)
+    }
+}
+
 
 /// The declaration of a symbol representation as one or many {@link Location locations}.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -32,6 +44,18 @@ pub enum Declaration {
     Location(Location),
     /// `LocationList`.
     List(Vec<Location>),
+}
+
+impl From<Location> for Declaration {
+    fn from(value: Location) -> Self {
+        Self::Location(value)
+    }
+}
+
+impl From<Vec<Location>> for Declaration {
+    fn from(value: Vec<Location>) -> Self {
+        Self::List(value)
+    }
 }
 
 
@@ -53,6 +77,24 @@ pub enum InlineValue {
     EvaluatableExpression(InlineValueEvaluatableExpression),
 }
 
+impl From<InlineValueText> for InlineValue {
+    fn from(value: InlineValueText) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<InlineValueVariableLookup> for InlineValue {
+    fn from(value: InlineValueVariableLookup) -> Self {
+        Self::VariableLookup(value)
+    }
+}
+
+impl From<InlineValueEvaluatableExpression> for InlineValue {
+    fn from(value: InlineValueEvaluatableExpression) -> Self {
+        Self::EvaluatableExpression(value)
+    }
+}
+
 
 /// The result of a document diagnostic pull request. A report can
 /// either be a full report containing all diagnostics for the
@@ -70,6 +112,18 @@ pub enum DocumentDiagnosticReport {
     Unchanged(RelatedUnchangedDocumentDiagnosticReport),
 }
 
+impl From<RelatedFullDocumentDiagnosticReport> for DocumentDiagnosticReport {
+    fn from(value: RelatedFullDocumentDiagnosticReport) -> Self {
+        Self::Full(value)
+    }
+}
+
+impl From<RelatedUnchangedDocumentDiagnosticReport> for DocumentDiagnosticReport {
+    fn from(value: RelatedUnchangedDocumentDiagnosticReport) -> Self {
+        Self::Unchanged(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PrepareRenameResult {
@@ -78,11 +132,41 @@ pub enum PrepareRenameResult {
     PrepareRenameDefaultBehavior(PrepareRenameDefaultBehavior),
 }
 
+impl From<Range> for PrepareRenameResult {
+    fn from(value: Range) -> Self {
+        Self::Range(value)
+    }
+}
+
+impl From<PrepareRenamePlaceholder> for PrepareRenameResult {
+    fn from(value: PrepareRenamePlaceholder) -> Self {
+        Self::PrepareRenamePlaceholder(value)
+    }
+}
+
+impl From<PrepareRenameDefaultBehavior> for PrepareRenameResult {
+    fn from(value: PrepareRenameDefaultBehavior) -> Self {
+        Self::PrepareRenameDefaultBehavior(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ProgressToken {
     Integer(i32),
     String(String),
+}
+
+impl From<i32> for ProgressToken {
+    fn from(value: i32) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<String> for ProgressToken {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
 }
 
 
@@ -98,6 +182,18 @@ pub enum WorkspaceDocumentDiagnosticReport {
     Unchanged(WorkspaceUnchangedDocumentDiagnosticReport),
 }
 
+impl From<WorkspaceFullDocumentDiagnosticReport> for WorkspaceDocumentDiagnosticReport {
+    fn from(value: WorkspaceFullDocumentDiagnosticReport) -> Self {
+        Self::Full(value)
+    }
+}
+
+impl From<WorkspaceUnchangedDocumentDiagnosticReport> for WorkspaceDocumentDiagnosticReport {
+    fn from(value: WorkspaceUnchangedDocumentDiagnosticReport) -> Self {
+        Self::Unchanged(value)
+    }
+}
+
 
 /// An event describing a change to a text document. If only a text is provided
 /// it is considered to be the full content of the document.
@@ -108,6 +204,18 @@ pub enum TextDocumentContentChangeEvent {
     Partial(TextDocumentContentChangePartial),
     /// `TextDocumentContentChangeWholeDocument`.
     WholeDocument(TextDocumentContentChangeWholeDocument),
+}
+
+impl From<TextDocumentContentChangePartial> for TextDocumentContentChangeEvent {
+    fn from(value: TextDocumentContentChangePartial) -> Self {
+        Self::Partial(value)
+    }
+}
+
+impl From<TextDocumentContentChangeWholeDocument> for TextDocumentContentChangeEvent {
+    fn from(value: TextDocumentContentChangeWholeDocument) -> Self {
+        Self::WholeDocument(value)
+    }
 }
 
 
@@ -131,6 +239,18 @@ pub enum MarkedString {
     WithLanguage(MarkedStringWithLanguage),
 }
 
+impl From<String> for MarkedString {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<MarkedStringWithLanguage> for MarkedString {
+    fn from(value: MarkedStringWithLanguage) -> Self {
+        Self::WithLanguage(value)
+    }
+}
+
 
 /// A document filter describes a top level text document or
 /// a notebook cell document.
@@ -143,6 +263,18 @@ pub enum DocumentFilter {
     NotebookCellTextDocumentFilter(NotebookCellTextDocumentFilter),
 }
 
+impl From<TextDocumentFilter> for DocumentFilter {
+    fn from(value: TextDocumentFilter) -> Self {
+        Self::TextDocumentFilter(value)
+    }
+}
+
+impl From<NotebookCellTextDocumentFilter> for DocumentFilter {
+    fn from(value: NotebookCellTextDocumentFilter) -> Self {
+        Self::NotebookCellTextDocumentFilter(value)
+    }
+}
+
 
 /// The glob pattern. Either a string pattern or a relative pattern.
 ///
@@ -152,6 +284,18 @@ pub enum DocumentFilter {
 pub enum GlobPattern {
     Pattern(Pattern),
     RelativePattern(RelativePattern),
+}
+
+impl From<Pattern> for GlobPattern {
+    fn from(value: Pattern) -> Self {
+        Self::Pattern(value)
+    }
+}
+
+impl From<RelativePattern> for GlobPattern {
+    fn from(value: RelativePattern) -> Self {
+        Self::RelativePattern(value)
+    }
 }
 
 
@@ -182,6 +326,24 @@ pub enum TextDocumentFilter {
     Pattern(TextDocumentFilterPattern),
 }
 
+impl From<TextDocumentFilterLanguage> for TextDocumentFilter {
+    fn from(value: TextDocumentFilterLanguage) -> Self {
+        Self::Language(value)
+    }
+}
+
+impl From<TextDocumentFilterScheme> for TextDocumentFilter {
+    fn from(value: TextDocumentFilterScheme) -> Self {
+        Self::Scheme(value)
+    }
+}
+
+impl From<TextDocumentFilterPattern> for TextDocumentFilter {
+    fn from(value: TextDocumentFilterPattern) -> Self {
+        Self::Pattern(value)
+    }
+}
+
 
 /// A notebook document filter denotes a notebook document by
 /// different properties. The properties will be match
@@ -199,12 +361,48 @@ pub enum NotebookDocumentFilter {
     Pattern(NotebookDocumentFilterPattern),
 }
 
+impl From<NotebookDocumentFilterNotebookType> for NotebookDocumentFilter {
+    fn from(value: NotebookDocumentFilterNotebookType) -> Self {
+        Self::NotebookType(value)
+    }
+}
+
+impl From<NotebookDocumentFilterScheme> for NotebookDocumentFilter {
+    fn from(value: NotebookDocumentFilterScheme) -> Self {
+        Self::Scheme(value)
+    }
+}
+
+impl From<NotebookDocumentFilterPattern> for NotebookDocumentFilter {
+    fn from(value: NotebookDocumentFilterPattern) -> Self {
+        Self::Pattern(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ImplementationResponse {
     Definition(Definition),
     DefinitionLinkList(Vec<DefinitionLink>),
     LocationList(Vec<Location>),
+}
+
+impl From<Definition> for ImplementationResponse {
+    fn from(value: Definition) -> Self {
+        Self::Definition(value)
+    }
+}
+
+impl From<Vec<DefinitionLink>> for ImplementationResponse {
+    fn from(value: Vec<DefinitionLink>) -> Self {
+        Self::DefinitionLinkList(value)
+    }
+}
+
+impl From<Vec<Location>> for ImplementationResponse {
+    fn from(value: Vec<Location>) -> Self {
+        Self::LocationList(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -215,6 +413,24 @@ pub enum TypeDefinitionResponse {
     LocationList(Vec<Location>),
 }
 
+impl From<Definition> for TypeDefinitionResponse {
+    fn from(value: Definition) -> Self {
+        Self::Definition(value)
+    }
+}
+
+impl From<Vec<DefinitionLink>> for TypeDefinitionResponse {
+    fn from(value: Vec<DefinitionLink>) -> Self {
+        Self::DefinitionLinkList(value)
+    }
+}
+
+impl From<Vec<Location>> for TypeDefinitionResponse {
+    fn from(value: Vec<Location>) -> Self {
+        Self::LocationList(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeclarationResponse {
@@ -223,12 +439,42 @@ pub enum DeclarationResponse {
     LocationList(Vec<Location>),
 }
 
+impl From<Declaration> for DeclarationResponse {
+    fn from(value: Declaration) -> Self {
+        Self::Declaration(value)
+    }
+}
+
+impl From<Vec<DeclarationLink>> for DeclarationResponse {
+    fn from(value: Vec<DeclarationLink>) -> Self {
+        Self::DeclarationLinkList(value)
+    }
+}
+
+impl From<Vec<Location>> for DeclarationResponse {
+    fn from(value: Vec<Location>) -> Self {
+        Self::LocationList(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensResponse {
     SemanticTokens(SemanticTokens),
     /// `SemanticTokensPartialResult`.
     PartialResult(SemanticTokensPartialResult),
+}
+
+impl From<SemanticTokens> for SemanticTokensResponse {
+    fn from(value: SemanticTokens) -> Self {
+        Self::SemanticTokens(value)
+    }
+}
+
+impl From<SemanticTokensPartialResult> for SemanticTokensResponse {
+    fn from(value: SemanticTokensPartialResult) -> Self {
+        Self::PartialResult(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -243,12 +489,48 @@ pub enum SemanticTokensDeltaResponse {
     DeltaPartialResult(SemanticTokensDeltaPartialResult),
 }
 
+impl From<SemanticTokens> for SemanticTokensDeltaResponse {
+    fn from(value: SemanticTokens) -> Self {
+        Self::SemanticTokens(value)
+    }
+}
+
+impl From<SemanticTokensDelta> for SemanticTokensDeltaResponse {
+    fn from(value: SemanticTokensDelta) -> Self {
+        Self::Delta(value)
+    }
+}
+
+impl From<SemanticTokensPartialResult> for SemanticTokensDeltaResponse {
+    fn from(value: SemanticTokensPartialResult) -> Self {
+        Self::PartialResult(value)
+    }
+}
+
+impl From<SemanticTokensDeltaPartialResult> for SemanticTokensDeltaResponse {
+    fn from(value: SemanticTokensDeltaPartialResult) -> Self {
+        Self::DeltaPartialResult(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensRangeResponse {
     SemanticTokens(SemanticTokens),
     /// `SemanticTokensPartialResult`.
     PartialResult(SemanticTokensPartialResult),
+}
+
+impl From<SemanticTokens> for SemanticTokensRangeResponse {
+    fn from(value: SemanticTokens) -> Self {
+        Self::SemanticTokens(value)
+    }
+}
+
+impl From<SemanticTokensPartialResult> for SemanticTokensRangeResponse {
+    fn from(value: SemanticTokensPartialResult) -> Self {
+        Self::PartialResult(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -259,12 +541,36 @@ pub enum DocumentDiagnosticResponse {
     PartialResult(DocumentDiagnosticReportPartialResult),
 }
 
+impl From<DocumentDiagnosticReport> for DocumentDiagnosticResponse {
+    fn from(value: DocumentDiagnosticReport) -> Self {
+        Self::DocumentDiagnosticReport(value)
+    }
+}
+
+impl From<DocumentDiagnosticReportPartialResult> for DocumentDiagnosticResponse {
+    fn from(value: DocumentDiagnosticReportPartialResult) -> Self {
+        Self::PartialResult(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceDiagnosticResponse {
     WorkspaceDiagnosticReport(WorkspaceDiagnosticReport),
     /// `WorkspaceDiagnosticReportPartialResult`.
     PartialResult(WorkspaceDiagnosticReportPartialResult),
+}
+
+impl From<WorkspaceDiagnosticReport> for WorkspaceDiagnosticResponse {
+    fn from(value: WorkspaceDiagnosticReport) -> Self {
+        Self::WorkspaceDiagnosticReport(value)
+    }
+}
+
+impl From<WorkspaceDiagnosticReportPartialResult> for WorkspaceDiagnosticResponse {
+    fn from(value: WorkspaceDiagnosticReportPartialResult) -> Self {
+        Self::PartialResult(value)
+    }
 }
 
 #[cfg(feature = "proposed")]
@@ -277,6 +583,20 @@ pub enum InlineCompletionResponse {
     ItemList(Vec<InlineCompletionItem>),
 }
 
+#[cfg(feature = "proposed")]
+impl From<InlineCompletionList> for InlineCompletionResponse {
+    fn from(value: InlineCompletionList) -> Self {
+        Self::List(value)
+    }
+}
+
+#[cfg(feature = "proposed")]
+impl From<Vec<InlineCompletionItem>> for InlineCompletionResponse {
+    fn from(value: Vec<InlineCompletionItem>) -> Self {
+        Self::ItemList(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CompletionResponse {
@@ -284,6 +604,18 @@ pub enum CompletionResponse {
     ItemList(Vec<CompletionItem>),
     /// `CompletionList`.
     List(CompletionList),
+}
+
+impl From<Vec<CompletionItem>> for CompletionResponse {
+    fn from(value: Vec<CompletionItem>) -> Self {
+        Self::ItemList(value)
+    }
+}
+
+impl From<CompletionList> for CompletionResponse {
+    fn from(value: CompletionList) -> Self {
+        Self::List(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -294,11 +626,41 @@ pub enum DefinitionResponse {
     LocationList(Vec<Location>),
 }
 
+impl From<Definition> for DefinitionResponse {
+    fn from(value: Definition) -> Self {
+        Self::Definition(value)
+    }
+}
+
+impl From<Vec<DefinitionLink>> for DefinitionResponse {
+    fn from(value: Vec<DefinitionLink>) -> Self {
+        Self::DefinitionLinkList(value)
+    }
+}
+
+impl From<Vec<Location>> for DefinitionResponse {
+    fn from(value: Vec<Location>) -> Self {
+        Self::LocationList(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentSymbolResponse {
     SymbolInformationList(Vec<SymbolInformation>),
     DocumentSymbolList(Vec<DocumentSymbol>),
+}
+
+impl From<Vec<SymbolInformation>> for DocumentSymbolResponse {
+    fn from(value: Vec<SymbolInformation>) -> Self {
+        Self::SymbolInformationList(value)
+    }
+}
+
+impl From<Vec<DocumentSymbol>> for DocumentSymbolResponse {
+    fn from(value: Vec<DocumentSymbol>) -> Self {
+        Self::DocumentSymbolList(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -308,11 +670,35 @@ pub enum CodeActionResponseItem {
     CodeAction(CodeAction),
 }
 
+impl From<Command> for CodeActionResponseItem {
+    fn from(value: Command) -> Self {
+        Self::Command(value)
+    }
+}
+
+impl From<CodeAction> for CodeActionResponseItem {
+    fn from(value: CodeAction) -> Self {
+        Self::CodeAction(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceSymbolResponse {
     SymbolInformationList(Vec<SymbolInformation>),
     WorkspaceSymbolList(Vec<WorkspaceSymbol>),
+}
+
+impl From<Vec<SymbolInformation>> for WorkspaceSymbolResponse {
+    fn from(value: Vec<SymbolInformation>) -> Self {
+        Self::SymbolInformationList(value)
+    }
+}
+
+impl From<Vec<WorkspaceSymbol>> for WorkspaceSymbolResponse {
+    fn from(value: Vec<WorkspaceSymbol>) -> Self {
+        Self::WorkspaceSymbolList(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -322,12 +708,36 @@ pub enum SemanticTokensRange {
     Object(serde_json::Value),
 }
 
+impl From<bool> for SemanticTokensRange {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<serde_json::Value> for SemanticTokensRange {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Object(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensFull {
     Bool(bool),
     /// `SemanticTokensFullDelta`.
     Delta(SemanticTokensFullDelta),
+}
+
+impl From<bool> for SemanticTokensFull {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<SemanticTokensFullDelta> for SemanticTokensFull {
+    fn from(value: SemanticTokensFullDelta) -> Self {
+        Self::Delta(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -339,6 +749,30 @@ pub enum WorkspaceEditDocumentChangesItem {
     DeleteFile(DeleteFile),
 }
 
+impl From<TextDocumentEdit> for WorkspaceEditDocumentChangesItem {
+    fn from(value: TextDocumentEdit) -> Self {
+        Self::TextDocumentEdit(value)
+    }
+}
+
+impl From<CreateFile> for WorkspaceEditDocumentChangesItem {
+    fn from(value: CreateFile) -> Self {
+        Self::CreateFile(value)
+    }
+}
+
+impl From<RenameFile> for WorkspaceEditDocumentChangesItem {
+    fn from(value: RenameFile) -> Self {
+        Self::RenameFile(value)
+    }
+}
+
+impl From<DeleteFile> for WorkspaceEditDocumentChangesItem {
+    fn from(value: DeleteFile) -> Self {
+        Self::DeleteFile(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlayHintLabel {
@@ -347,11 +781,35 @@ pub enum InlayHintLabel {
     PartList(Vec<InlayHintLabelPart>),
 }
 
+impl From<String> for InlayHintLabel {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<Vec<InlayHintLabelPart>> for InlayHintLabel {
+    fn from(value: Vec<InlayHintLabelPart>) -> Self {
+        Self::PartList(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlayHintTooltip {
     String(String),
     MarkupContent(MarkupContent),
+}
+
+impl From<String> for InlayHintTooltip {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<MarkupContent> for InlayHintTooltip {
+    fn from(value: MarkupContent) -> Self {
+        Self::MarkupContent(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -363,6 +821,18 @@ pub enum RelatedDocumentDiagnosticReport {
     Unchanged(UnchangedDocumentDiagnosticReport),
 }
 
+impl From<FullDocumentDiagnosticReport> for RelatedDocumentDiagnosticReport {
+    fn from(value: FullDocumentDiagnosticReport) -> Self {
+        Self::Full(value)
+    }
+}
+
+impl From<UnchangedDocumentDiagnosticReport> for RelatedDocumentDiagnosticReport {
+    fn from(value: UnchangedDocumentDiagnosticReport) -> Self {
+        Self::Unchanged(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NotebookSelectorItem {
@@ -370,6 +840,18 @@ pub enum NotebookSelectorItem {
     Notebook(NotebookDocumentFilterWithNotebook),
     /// `NotebookDocumentFilterWithCells`.
     Cells(NotebookDocumentFilterWithCells),
+}
+
+impl From<NotebookDocumentFilterWithNotebook> for NotebookSelectorItem {
+    fn from(value: NotebookDocumentFilterWithNotebook) -> Self {
+        Self::Notebook(value)
+    }
+}
+
+impl From<NotebookDocumentFilterWithCells> for NotebookSelectorItem {
+    fn from(value: NotebookDocumentFilterWithCells) -> Self {
+        Self::Cells(value)
+    }
 }
 
 #[cfg(feature = "proposed")]
@@ -380,11 +862,37 @@ pub enum InlineCompletionItemInsertText {
     StringValue(StringValue),
 }
 
+#[cfg(feature = "proposed")]
+impl From<String> for InlineCompletionItemInsertText {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+#[cfg(feature = "proposed")]
+impl From<StringValue> for InlineCompletionItemInsertText {
+    fn from(value: StringValue) -> Self {
+        Self::StringValue(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DidChangeConfigurationSection {
     String(String),
     StringList(Vec<String>),
+}
+
+impl From<String> for DidChangeConfigurationSection {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<Vec<String>> for DidChangeConfigurationSection {
+    fn from(value: Vec<String>) -> Self {
+        Self::StringList(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -394,11 +902,35 @@ pub enum CompletionItemDocumentation {
     MarkupContent(MarkupContent),
 }
 
+impl From<String> for CompletionItemDocumentation {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<MarkupContent> for CompletionItemDocumentation {
+    fn from(value: MarkupContent) -> Self {
+        Self::MarkupContent(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CompletionItemTextEdit {
     TextEdit(TextEdit),
     InsertReplaceEdit(InsertReplaceEdit),
+}
+
+impl From<TextEdit> for CompletionItemTextEdit {
+    fn from(value: TextEdit) -> Self {
+        Self::TextEdit(value)
+    }
+}
+
+impl From<InsertReplaceEdit> for CompletionItemTextEdit {
+    fn from(value: InsertReplaceEdit) -> Self {
+        Self::InsertReplaceEdit(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -409,12 +941,42 @@ pub enum HoverContents {
     MarkedStringList(Vec<MarkedString>),
 }
 
+impl From<MarkupContent> for HoverContents {
+    fn from(value: MarkupContent) -> Self {
+        Self::MarkupContent(value)
+    }
+}
+
+impl From<MarkedString> for HoverContents {
+    fn from(value: MarkedString) -> Self {
+        Self::MarkedString(value)
+    }
+}
+
+impl From<Vec<MarkedString>> for HoverContents {
+    fn from(value: Vec<MarkedString>) -> Self {
+        Self::MarkedStringList(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceSymbolLocation {
     Location(Location),
     /// `LocationUriOnly`.
     UriOnly(LocationUriOnly),
+}
+
+impl From<Location> for WorkspaceSymbolLocation {
+    fn from(value: Location) -> Self {
+        Self::Location(value)
+    }
+}
+
+impl From<LocationUriOnly> for WorkspaceSymbolLocation {
+    fn from(value: LocationUriOnly) -> Self {
+        Self::UriOnly(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -424,6 +986,18 @@ pub enum CancelParamsId {
     String(String),
 }
 
+impl From<i32> for CancelParamsId {
+    fn from(value: i32) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<String> for CancelParamsId {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TextDocumentEditEditsItem {
@@ -431,11 +1005,35 @@ pub enum TextDocumentEditEditsItem {
     AnnotatedTextEdit(AnnotatedTextEdit),
 }
 
+impl From<TextEdit> for TextDocumentEditEditsItem {
+    fn from(value: TextEdit) -> Self {
+        Self::TextEdit(value)
+    }
+}
+
+impl From<AnnotatedTextEdit> for TextDocumentEditEditsItem {
+    fn from(value: AnnotatedTextEdit) -> Self {
+        Self::AnnotatedTextEdit(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlayHintLabelPartTooltip {
     String(String),
     MarkupContent(MarkupContent),
+}
+
+impl From<String> for InlayHintLabelPartTooltip {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<MarkupContent> for InlayHintLabelPartTooltip {
+    fn from(value: MarkupContent) -> Self {
+        Self::MarkupContent(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -447,6 +1045,18 @@ pub enum TextDocumentSync {
     Kind(TextDocumentSyncKind),
 }
 
+impl From<TextDocumentSyncOptions> for TextDocumentSync {
+    fn from(value: TextDocumentSyncOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<TextDocumentSyncKind> for TextDocumentSync {
+    fn from(value: TextDocumentSyncKind) -> Self {
+        Self::Kind(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NotebookDocumentSync {
@@ -456,12 +1066,36 @@ pub enum NotebookDocumentSync {
     RegistrationOptions(NotebookDocumentSyncRegistrationOptions),
 }
 
+impl From<NotebookDocumentSyncOptions> for NotebookDocumentSync {
+    fn from(value: NotebookDocumentSyncOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<NotebookDocumentSyncRegistrationOptions> for NotebookDocumentSync {
+    fn from(value: NotebookDocumentSyncRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum HoverProvider {
     Bool(bool),
     /// `HoverOptions`.
     Options(HoverOptions),
+}
+
+impl From<bool> for HoverProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<HoverOptions> for HoverProvider {
+    fn from(value: HoverOptions) -> Self {
+        Self::Options(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -474,12 +1108,42 @@ pub enum DeclarationProvider {
     RegistrationOptions(DeclarationRegistrationOptions),
 }
 
+impl From<bool> for DeclarationProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DeclarationOptions> for DeclarationProvider {
+    fn from(value: DeclarationOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<DeclarationRegistrationOptions> for DeclarationProvider {
+    fn from(value: DeclarationRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DefinitionProvider {
     Bool(bool),
     /// `DefinitionOptions`.
     Options(DefinitionOptions),
+}
+
+impl From<bool> for DefinitionProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DefinitionOptions> for DefinitionProvider {
+    fn from(value: DefinitionOptions) -> Self {
+        Self::Options(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -492,6 +1156,24 @@ pub enum TypeDefinitionProvider {
     RegistrationOptions(TypeDefinitionRegistrationOptions),
 }
 
+impl From<bool> for TypeDefinitionProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<TypeDefinitionOptions> for TypeDefinitionProvider {
+    fn from(value: TypeDefinitionOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<TypeDefinitionRegistrationOptions> for TypeDefinitionProvider {
+    fn from(value: TypeDefinitionRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ImplementationProvider {
@@ -502,11 +1184,41 @@ pub enum ImplementationProvider {
     RegistrationOptions(ImplementationRegistrationOptions),
 }
 
+impl From<bool> for ImplementationProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<ImplementationOptions> for ImplementationProvider {
+    fn from(value: ImplementationOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<ImplementationRegistrationOptions> for ImplementationProvider {
+    fn from(value: ImplementationRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ReferencesProvider {
     Bool(bool),
     ReferenceOptions(ReferenceOptions),
+}
+
+impl From<bool> for ReferencesProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<ReferenceOptions> for ReferencesProvider {
+    fn from(value: ReferenceOptions) -> Self {
+        Self::ReferenceOptions(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -517,6 +1229,18 @@ pub enum DocumentHighlightProvider {
     Options(DocumentHighlightOptions),
 }
 
+impl From<bool> for DocumentHighlightProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DocumentHighlightOptions> for DocumentHighlightProvider {
+    fn from(value: DocumentHighlightOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentSymbolProvider {
@@ -525,12 +1249,36 @@ pub enum DocumentSymbolProvider {
     Options(DocumentSymbolOptions),
 }
 
+impl From<bool> for DocumentSymbolProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DocumentSymbolOptions> for DocumentSymbolProvider {
+    fn from(value: DocumentSymbolOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CodeActionProvider {
     Bool(bool),
     /// `CodeActionOptions`.
     Options(CodeActionOptions),
+}
+
+impl From<bool> for CodeActionProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<CodeActionOptions> for CodeActionProvider {
+    fn from(value: CodeActionOptions) -> Self {
+        Self::Options(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -543,12 +1291,42 @@ pub enum ColorProvider {
     RegistrationOptions(DocumentColorRegistrationOptions),
 }
 
+impl From<bool> for ColorProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DocumentColorOptions> for ColorProvider {
+    fn from(value: DocumentColorOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<DocumentColorRegistrationOptions> for ColorProvider {
+    fn from(value: DocumentColorRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceSymbolProvider {
     Bool(bool),
     /// `WorkspaceSymbolOptions`.
     Options(WorkspaceSymbolOptions),
+}
+
+impl From<bool> for WorkspaceSymbolProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<WorkspaceSymbolOptions> for WorkspaceSymbolProvider {
+    fn from(value: WorkspaceSymbolOptions) -> Self {
+        Self::Options(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -559,6 +1337,18 @@ pub enum DocumentFormattingProvider {
     Options(DocumentFormattingOptions),
 }
 
+impl From<bool> for DocumentFormattingProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DocumentFormattingOptions> for DocumentFormattingProvider {
+    fn from(value: DocumentFormattingOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentRangeFormattingProvider {
@@ -567,12 +1357,36 @@ pub enum DocumentRangeFormattingProvider {
     Options(DocumentRangeFormattingOptions),
 }
 
+impl From<bool> for DocumentRangeFormattingProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<DocumentRangeFormattingOptions> for DocumentRangeFormattingProvider {
+    fn from(value: DocumentRangeFormattingOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RenameProvider {
     Bool(bool),
     /// `RenameOptions`.
     Options(RenameOptions),
+}
+
+impl From<bool> for RenameProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<RenameOptions> for RenameProvider {
+    fn from(value: RenameOptions) -> Self {
+        Self::Options(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -585,6 +1399,24 @@ pub enum FoldingRangeProvider {
     RegistrationOptions(FoldingRangeRegistrationOptions),
 }
 
+impl From<bool> for FoldingRangeProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<FoldingRangeOptions> for FoldingRangeProvider {
+    fn from(value: FoldingRangeOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<FoldingRangeRegistrationOptions> for FoldingRangeProvider {
+    fn from(value: FoldingRangeRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SelectionRangeProvider {
@@ -593,6 +1425,24 @@ pub enum SelectionRangeProvider {
     Options(SelectionRangeOptions),
     /// `SelectionRangeRegistrationOptions`.
     RegistrationOptions(SelectionRangeRegistrationOptions),
+}
+
+impl From<bool> for SelectionRangeProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<SelectionRangeOptions> for SelectionRangeProvider {
+    fn from(value: SelectionRangeOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<SelectionRangeRegistrationOptions> for SelectionRangeProvider {
+    fn from(value: SelectionRangeRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -605,6 +1455,24 @@ pub enum CallHierarchyProvider {
     RegistrationOptions(CallHierarchyRegistrationOptions),
 }
 
+impl From<bool> for CallHierarchyProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<CallHierarchyOptions> for CallHierarchyProvider {
+    fn from(value: CallHierarchyOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<CallHierarchyRegistrationOptions> for CallHierarchyProvider {
+    fn from(value: CallHierarchyRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LinkedEditingRangeProvider {
@@ -615,6 +1483,24 @@ pub enum LinkedEditingRangeProvider {
     RegistrationOptions(LinkedEditingRangeRegistrationOptions),
 }
 
+impl From<bool> for LinkedEditingRangeProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<LinkedEditingRangeOptions> for LinkedEditingRangeProvider {
+    fn from(value: LinkedEditingRangeOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<LinkedEditingRangeRegistrationOptions> for LinkedEditingRangeProvider {
+    fn from(value: LinkedEditingRangeRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensProvider {
@@ -622,6 +1508,18 @@ pub enum SemanticTokensProvider {
     Options(SemanticTokensOptions),
     /// `SemanticTokensRegistrationOptions`.
     RegistrationOptions(SemanticTokensRegistrationOptions),
+}
+
+impl From<SemanticTokensOptions> for SemanticTokensProvider {
+    fn from(value: SemanticTokensOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<SemanticTokensRegistrationOptions> for SemanticTokensProvider {
+    fn from(value: SemanticTokensRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -634,6 +1532,24 @@ pub enum MonikerProvider {
     RegistrationOptions(MonikerRegistrationOptions),
 }
 
+impl From<bool> for MonikerProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<MonikerOptions> for MonikerProvider {
+    fn from(value: MonikerOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<MonikerRegistrationOptions> for MonikerProvider {
+    fn from(value: MonikerRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TypeHierarchyProvider {
@@ -642,6 +1558,24 @@ pub enum TypeHierarchyProvider {
     Options(TypeHierarchyOptions),
     /// `TypeHierarchyRegistrationOptions`.
     RegistrationOptions(TypeHierarchyRegistrationOptions),
+}
+
+impl From<bool> for TypeHierarchyProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<TypeHierarchyOptions> for TypeHierarchyProvider {
+    fn from(value: TypeHierarchyOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<TypeHierarchyRegistrationOptions> for TypeHierarchyProvider {
+    fn from(value: TypeHierarchyRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -654,6 +1588,24 @@ pub enum InlineValueProvider {
     RegistrationOptions(InlineValueRegistrationOptions),
 }
 
+impl From<bool> for InlineValueProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<InlineValueOptions> for InlineValueProvider {
+    fn from(value: InlineValueOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<InlineValueRegistrationOptions> for InlineValueProvider {
+    fn from(value: InlineValueRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlayHintProvider {
@@ -662,6 +1614,24 @@ pub enum InlayHintProvider {
     Options(InlayHintOptions),
     /// `InlayHintRegistrationOptions`.
     RegistrationOptions(InlayHintRegistrationOptions),
+}
+
+impl From<bool> for InlayHintProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<InlayHintOptions> for InlayHintProvider {
+    fn from(value: InlayHintOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<InlayHintRegistrationOptions> for InlayHintProvider {
+    fn from(value: InlayHintRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -673,6 +1643,18 @@ pub enum DiagnosticProvider {
     RegistrationOptions(DiagnosticRegistrationOptions),
 }
 
+impl From<DiagnosticOptions> for DiagnosticProvider {
+    fn from(value: DiagnosticOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+impl From<DiagnosticRegistrationOptions> for DiagnosticProvider {
+    fn from(value: DiagnosticRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[cfg(feature = "proposed")]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -682,11 +1664,37 @@ pub enum InlineCompletionProvider {
     Options(InlineCompletionOptions),
 }
 
+#[cfg(feature = "proposed")]
+impl From<bool> for InlineCompletionProvider {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+#[cfg(feature = "proposed")]
+impl From<InlineCompletionOptions> for InlineCompletionProvider {
+    fn from(value: InlineCompletionOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DiagnosticCode {
     Integer(i32),
     String(String),
+}
+
+impl From<i32> for DiagnosticCode {
+    fn from(value: i32) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<String> for DiagnosticCode {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -696,11 +1704,35 @@ pub enum CompletionItemDefaultsEditRange {
     EditRangeWithInsertReplace(EditRangeWithInsertReplace),
 }
 
+impl From<Range> for CompletionItemDefaultsEditRange {
+    fn from(value: Range) -> Self {
+        Self::Range(value)
+    }
+}
+
+impl From<EditRangeWithInsertReplace> for CompletionItemDefaultsEditRange {
+    fn from(value: EditRangeWithInsertReplace) -> Self {
+        Self::EditRangeWithInsertReplace(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SignatureInformationDocumentation {
     String(String),
     MarkupContent(MarkupContent),
+}
+
+impl From<String> for SignatureInformationDocumentation {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<MarkupContent> for SignatureInformationDocumentation {
+    fn from(value: MarkupContent) -> Self {
+        Self::MarkupContent(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -710,11 +1742,35 @@ pub enum NotebookDocumentFilterNotebook {
     NotebookDocumentFilter(NotebookDocumentFilter),
 }
 
+impl From<String> for NotebookDocumentFilterNotebook {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<NotebookDocumentFilter> for NotebookDocumentFilterNotebook {
+    fn from(value: NotebookDocumentFilter) -> Self {
+        Self::NotebookDocumentFilter(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TextDocumentSyncSave {
     Bool(bool),
     SaveOptions(SaveOptions),
+}
+
+impl From<bool> for TextDocumentSyncSave {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<SaveOptions> for TextDocumentSyncSave {
+    fn from(value: SaveOptions) -> Self {
+        Self::SaveOptions(value)
+    }
 }
 
 #[cfg(feature = "proposed")]
@@ -727,11 +1783,37 @@ pub enum WorkspaceTextDocumentContent {
     RegistrationOptions(TextDocumentContentRegistrationOptions),
 }
 
+#[cfg(feature = "proposed")]
+impl From<TextDocumentContentOptions> for WorkspaceTextDocumentContent {
+    fn from(value: TextDocumentContentOptions) -> Self {
+        Self::Options(value)
+    }
+}
+
+#[cfg(feature = "proposed")]
+impl From<TextDocumentContentRegistrationOptions> for WorkspaceTextDocumentContent {
+    fn from(value: TextDocumentContentRegistrationOptions) -> Self {
+        Self::RegistrationOptions(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ParameterInformationLabel {
     String(String),
     Tuple((u32, u32)),
+}
+
+impl From<String> for ParameterInformationLabel {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<(u32, u32)> for ParameterInformationLabel {
+    fn from(value: (u32, u32)) -> Self {
+        Self::Tuple(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -741,11 +1823,35 @@ pub enum ParameterInformationDocumentation {
     MarkupContent(MarkupContent),
 }
 
+impl From<String> for ParameterInformationDocumentation {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<MarkupContent> for ParameterInformationDocumentation {
+    fn from(value: MarkupContent) -> Self {
+        Self::MarkupContent(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceFoldersChangeNotifications {
     String(String),
     Bool(bool),
+}
+
+impl From<String> for WorkspaceFoldersChangeNotifications {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<bool> for WorkspaceFoldersChangeNotifications {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -755,11 +1861,35 @@ pub enum RelativePatternBaseUri {
     Uri(Uri),
 }
 
+impl From<WorkspaceFolder> for RelativePatternBaseUri {
+    fn from(value: WorkspaceFolder) -> Self {
+        Self::WorkspaceFolder(value)
+    }
+}
+
+impl From<Uri> for RelativePatternBaseUri {
+    fn from(value: Uri) -> Self {
+        Self::Uri(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ClientSemanticTokensRequestRange {
     Bool(bool),
     Object(serde_json::Value),
+}
+
+impl From<bool> for ClientSemanticTokensRequestRange {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<serde_json::Value> for ClientSemanticTokensRequestRange {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Object(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -768,4 +1898,16 @@ pub enum ClientSemanticTokensRequestFull {
     Bool(bool),
     /// `ClientSemanticTokensRequestFullDelta`.
     Delta(ClientSemanticTokensRequestFullDelta),
+}
+
+impl From<bool> for ClientSemanticTokensRequestFull {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<ClientSemanticTokensRequestFullDelta> for ClientSemanticTokensRequestFull {
+    fn from(value: ClientSemanticTokensRequestFullDelta) -> Self {
+        Self::Delta(value)
+    }
 }

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -1,0 +1,729 @@
+// DO NOT EDIT THIS GENERATED FILE.
+
+#![allow(deprecated)]
+#![allow(clippy::doc_lazy_continuation)]
+#![allow(clippy::large_enum_variant)]
+#![allow(rustdoc::invalid_codeblock_attributes)]
+#![allow(unused_imports)]
+
+use super::*;
+use crate::{HashMap, Uri};
+use serde::{Deserialize, Serialize};
+
+/// The definition of a symbol represented as one or many {@link Location locations}.
+/// For most programming languages there is only one location at which a symbol is
+/// defined.
+///
+/// Servers should prefer returning `DefinitionLink` over `Definition` if supported
+/// by the client.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Definition {
+    Location(Location),
+    LocationList(Vec<Location>),
+}
+
+/// The declaration of a symbol representation as one or many {@link Location locations}.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Declaration {
+    Location(Location),
+    LocationList(Vec<Location>),
+}
+
+/// Inline value information can be provided by different means:
+/// - directly as a text value (class InlineValueText).
+/// - as a name to use for a variable lookup (class InlineValueVariableLookup)
+/// - as an evaluatable expression (class InlineValueEvaluatableExpression)
+/// The InlineValue types combines all inline value types into one type.
+///
+/// @since 3.17.0
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InlineValue {
+    InlineValueText(InlineValueText),
+    InlineValueVariableLookup(InlineValueVariableLookup),
+    InlineValueEvaluatableExpression(InlineValueEvaluatableExpression),
+}
+
+/// The result of a document diagnostic pull request. A report can
+/// either be a full report containing all diagnostics for the
+/// requested document or an unchanged report indicating that nothing
+/// has changed in terms of diagnostics in comparison to the last
+/// pull request.
+///
+/// @since 3.17.0
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentDiagnosticReport {
+    RelatedFullDocumentDiagnosticReport(RelatedFullDocumentDiagnosticReport),
+    RelatedUnchangedDocumentDiagnosticReport(RelatedUnchangedDocumentDiagnosticReport),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PrepareRenameResult {
+    Range(Range),
+    PrepareRenamePlaceholder(PrepareRenamePlaceholder),
+    PrepareRenameDefaultBehavior(PrepareRenameDefaultBehavior),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProgressToken {
+    Integer(i32),
+    String(String),
+}
+
+/// A workspace diagnostic document report.
+///
+/// @since 3.17.0
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceDocumentDiagnosticReport {
+    WorkspaceFullDocumentDiagnosticReport(WorkspaceFullDocumentDiagnosticReport),
+    WorkspaceUnchangedDocumentDiagnosticReport(WorkspaceUnchangedDocumentDiagnosticReport),
+}
+
+/// An event describing a change to a text document. If only a text is provided
+/// it is considered to be the full content of the document.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TextDocumentContentChangeEvent {
+    TextDocumentContentChangePartial(TextDocumentContentChangePartial),
+    TextDocumentContentChangeWholeDocument(TextDocumentContentChangeWholeDocument),
+}
+
+/// MarkedString can be used to render human readable text. It is either a markdown string
+/// or a code-block that provides a language and a code snippet. The language identifier
+/// is semantically equal to the optional language identifier in fenced code blocks in GitHub
+/// issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+///
+/// The pair of a language and a value is an equivalent to markdown:
+/// ```${language}
+/// ${value}
+/// ```
+///
+/// Note that markdown strings will be sanitized - that means html will be escaped.
+/// @deprecated use MarkupContent instead.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MarkedString {
+    String(String),
+    MarkedStringWithLanguage(MarkedStringWithLanguage),
+}
+
+/// A document filter describes a top level text document or
+/// a notebook cell document.
+///
+/// @since 3.17.0 - support for NotebookCellTextDocumentFilter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentFilter {
+    TextDocumentFilter(TextDocumentFilter),
+    NotebookCellTextDocumentFilter(NotebookCellTextDocumentFilter),
+}
+
+/// The glob pattern. Either a string pattern or a relative pattern.
+///
+/// @since 3.17.0
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GlobPattern {
+    Pattern(Pattern),
+    RelativePattern(RelativePattern),
+}
+
+/// A document filter denotes a document by different properties like
+/// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+/// its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
+///
+/// Glob patterns can have the following syntax:
+/// - `*` to match one or more characters in a path segment
+/// - `?` to match on one character in a path segment
+/// - `**` to match any number of path segments, including none
+/// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+/// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+/// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+///
+/// @sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`
+/// @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
+///
+/// @since 3.17.0
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TextDocumentFilter {
+    TextDocumentFilterLanguage(TextDocumentFilterLanguage),
+    TextDocumentFilterScheme(TextDocumentFilterScheme),
+    TextDocumentFilterPattern(TextDocumentFilterPattern),
+}
+
+/// A notebook document filter denotes a notebook document by
+/// different properties. The properties will be match
+/// against the notebook's URI (same as with documents)
+///
+/// @since 3.17.0
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NotebookDocumentFilter {
+    NotebookDocumentFilterNotebookType(NotebookDocumentFilterNotebookType),
+    NotebookDocumentFilterScheme(NotebookDocumentFilterScheme),
+    NotebookDocumentFilterPattern(NotebookDocumentFilterPattern),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ImplementationRequestResult {
+    Definition(Definition),
+    DefinitionLinkList(Vec<DefinitionLink>),
+    LocationList(Vec<Location>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TypeDefinitionRequestResult {
+    Definition(Definition),
+    DefinitionLinkList(Vec<DefinitionLink>),
+    LocationList(Vec<Location>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeclarationRequestResult {
+    Declaration(Declaration),
+    DeclarationLinkList(Vec<DeclarationLink>),
+    LocationList(Vec<Location>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensRequestResult {
+    SemanticTokens(SemanticTokens),
+    SemanticTokensPartialResult(SemanticTokensPartialResult),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensDeltaRequestResult {
+    SemanticTokens(SemanticTokens),
+    SemanticTokensDelta(SemanticTokensDelta),
+    SemanticTokensPartialResult(SemanticTokensPartialResult),
+    SemanticTokensDeltaPartialResult(SemanticTokensDeltaPartialResult),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensRangeRequestResult {
+    SemanticTokens(SemanticTokens),
+    SemanticTokensPartialResult(SemanticTokensPartialResult),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentDiagnosticRequestResult {
+    DocumentDiagnosticReport(DocumentDiagnosticReport),
+    DocumentDiagnosticReportPartialResult(DocumentDiagnosticReportPartialResult),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceDiagnosticRequestResult {
+    WorkspaceDiagnosticReport(WorkspaceDiagnosticReport),
+    WorkspaceDiagnosticReportPartialResult(WorkspaceDiagnosticReportPartialResult),
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InlineCompletionRequestResult {
+    InlineCompletionList(InlineCompletionList),
+    InlineCompletionItemList(Vec<InlineCompletionItem>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompletionRequestResult {
+    CompletionItemList(Vec<CompletionItem>),
+    CompletionList(CompletionList),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DefinitionRequestResult {
+    Definition(Definition),
+    DefinitionLinkList(Vec<DefinitionLink>),
+    LocationList(Vec<Location>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentSymbolRequestResult {
+    SymbolInformationList(Vec<SymbolInformation>),
+    DocumentSymbolList(Vec<DocumentSymbol>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CodeActionRequestResultItem {
+    Command(Command),
+    CodeAction(CodeAction),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceSymbolRequestResult {
+    SymbolInformationList(Vec<SymbolInformation>),
+    WorkspaceSymbolList(Vec<WorkspaceSymbol>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensRegistrationOptionsRange {
+    Boolean(bool),
+    Object(serde_json::Value),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensRegistrationOptionsFull {
+    Boolean(bool),
+    SemanticTokensFullDelta(SemanticTokensFullDelta),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceEditDocumentChangesItem {
+    TextDocumentEdit(TextDocumentEdit),
+    CreateFile(CreateFile),
+    RenameFile(RenameFile),
+    DeleteFile(DeleteFile),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InlayHintLabel {
+    String(String),
+    InlayHintLabelPartList(Vec<InlayHintLabelPart>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InlayHintTooltip {
+    String(String),
+    MarkupContent(MarkupContent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DocumentDiagnosticReportPartialResultRelatedDocumentsValue {
+    FullDocumentDiagnosticReport(FullDocumentDiagnosticReport),
+    UnchangedDocumentDiagnosticReport(UnchangedDocumentDiagnosticReport),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NotebookDocumentSyncRegistrationOptionsNotebookSelectorItem {
+    NotebookDocumentFilterWithNotebook(NotebookDocumentFilterWithNotebook),
+    NotebookDocumentFilterWithCells(NotebookDocumentFilterWithCells),
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InlineCompletionItemInsertText {
+    String(String),
+    StringValue(StringValue),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DidChangeConfigurationRegistrationOptionsSection {
+    String(String),
+    StringList(Vec<String>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompletionItemDocumentation {
+    String(String),
+    MarkupContent(MarkupContent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompletionItemTextEdit {
+    TextEdit(TextEdit),
+    InsertReplaceEdit(InsertReplaceEdit),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum HoverContents {
+    MarkupContent(MarkupContent),
+    MarkedString(MarkedString),
+    MarkedStringList(Vec<MarkedString>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceSymbolLocation {
+    Location(Location),
+    LocationUriOnly(LocationUriOnly),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CancelParamsId {
+    Integer(i32),
+    String(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensOptionsRange {
+    Boolean(bool),
+    Object(serde_json::Value),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SemanticTokensOptionsFull {
+    Boolean(bool),
+    SemanticTokensFullDelta(SemanticTokensFullDelta),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TextDocumentEditEditsItem {
+    TextEdit(TextEdit),
+    AnnotatedTextEdit(AnnotatedTextEdit),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InlayHintLabelPartTooltip {
+    String(String),
+    MarkupContent(MarkupContent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RelatedFullDocumentDiagnosticReportRelatedDocumentsValue {
+    FullDocumentDiagnosticReport(FullDocumentDiagnosticReport),
+    UnchangedDocumentDiagnosticReport(UnchangedDocumentDiagnosticReport),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RelatedUnchangedDocumentDiagnosticReportRelatedDocumentsValue {
+    FullDocumentDiagnosticReport(FullDocumentDiagnosticReport),
+    UnchangedDocumentDiagnosticReport(UnchangedDocumentDiagnosticReport),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NotebookDocumentSyncOptionsNotebookSelectorItem {
+    NotebookDocumentFilterWithNotebook(NotebookDocumentFilterWithNotebook),
+    NotebookDocumentFilterWithCells(NotebookDocumentFilterWithCells),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesTextDocumentSync {
+    TextDocumentSyncOptions(TextDocumentSyncOptions),
+    TextDocumentSyncKind(TextDocumentSyncKind),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesNotebookDocumentSync {
+    NotebookDocumentSyncOptions(NotebookDocumentSyncOptions),
+    NotebookDocumentSyncRegistrationOptions(NotebookDocumentSyncRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesHoverProvider {
+    Boolean(bool),
+    HoverOptions(HoverOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDeclarationProvider {
+    Boolean(bool),
+    DeclarationOptions(DeclarationOptions),
+    DeclarationRegistrationOptions(DeclarationRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDefinitionProvider {
+    Boolean(bool),
+    DefinitionOptions(DefinitionOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesTypeDefinitionProvider {
+    Boolean(bool),
+    TypeDefinitionOptions(TypeDefinitionOptions),
+    TypeDefinitionRegistrationOptions(TypeDefinitionRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesImplementationProvider {
+    Boolean(bool),
+    ImplementationOptions(ImplementationOptions),
+    ImplementationRegistrationOptions(ImplementationRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesReferencesProvider {
+    Boolean(bool),
+    ReferenceOptions(ReferenceOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDocumentHighlightProvider {
+    Boolean(bool),
+    DocumentHighlightOptions(DocumentHighlightOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDocumentSymbolProvider {
+    Boolean(bool),
+    DocumentSymbolOptions(DocumentSymbolOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesCodeActionProvider {
+    Boolean(bool),
+    CodeActionOptions(CodeActionOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesColorProvider {
+    Boolean(bool),
+    DocumentColorOptions(DocumentColorOptions),
+    DocumentColorRegistrationOptions(DocumentColorRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesWorkspaceSymbolProvider {
+    Boolean(bool),
+    WorkspaceSymbolOptions(WorkspaceSymbolOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDocumentFormattingProvider {
+    Boolean(bool),
+    DocumentFormattingOptions(DocumentFormattingOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDocumentRangeFormattingProvider {
+    Boolean(bool),
+    DocumentRangeFormattingOptions(DocumentRangeFormattingOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesRenameProvider {
+    Boolean(bool),
+    RenameOptions(RenameOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesFoldingRangeProvider {
+    Boolean(bool),
+    FoldingRangeOptions(FoldingRangeOptions),
+    FoldingRangeRegistrationOptions(FoldingRangeRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesSelectionRangeProvider {
+    Boolean(bool),
+    SelectionRangeOptions(SelectionRangeOptions),
+    SelectionRangeRegistrationOptions(SelectionRangeRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesCallHierarchyProvider {
+    Boolean(bool),
+    CallHierarchyOptions(CallHierarchyOptions),
+    CallHierarchyRegistrationOptions(CallHierarchyRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesLinkedEditingRangeProvider {
+    Boolean(bool),
+    LinkedEditingRangeOptions(LinkedEditingRangeOptions),
+    LinkedEditingRangeRegistrationOptions(LinkedEditingRangeRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesSemanticTokensProvider {
+    SemanticTokensOptions(SemanticTokensOptions),
+    SemanticTokensRegistrationOptions(SemanticTokensRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesMonikerProvider {
+    Boolean(bool),
+    MonikerOptions(MonikerOptions),
+    MonikerRegistrationOptions(MonikerRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesTypeHierarchyProvider {
+    Boolean(bool),
+    TypeHierarchyOptions(TypeHierarchyOptions),
+    TypeHierarchyRegistrationOptions(TypeHierarchyRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesInlineValueProvider {
+    Boolean(bool),
+    InlineValueOptions(InlineValueOptions),
+    InlineValueRegistrationOptions(InlineValueRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesInlayHintProvider {
+    Boolean(bool),
+    InlayHintOptions(InlayHintOptions),
+    InlayHintRegistrationOptions(InlayHintRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesDiagnosticProvider {
+    DiagnosticOptions(DiagnosticOptions),
+    DiagnosticRegistrationOptions(DiagnosticRegistrationOptions),
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ServerCapabilitiesInlineCompletionProvider {
+    Boolean(bool),
+    InlineCompletionOptions(InlineCompletionOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DiagnosticCode {
+    Integer(i32),
+    String(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompletionItemDefaultsEditRange {
+    Range(Range),
+    EditRangeWithInsertReplace(EditRangeWithInsertReplace),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SignatureInformationDocumentation {
+    String(String),
+    MarkupContent(MarkupContent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NotebookDocumentFilterWithNotebookNotebook {
+    String(String),
+    NotebookDocumentFilter(NotebookDocumentFilter),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NotebookDocumentFilterWithCellsNotebook {
+    String(String),
+    NotebookDocumentFilter(NotebookDocumentFilter),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TextDocumentSyncOptionsSave {
+    Boolean(bool),
+    SaveOptions(SaveOptions),
+}
+
+#[cfg(feature = "proposed")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceOptionsTextDocumentContent {
+    TextDocumentContentOptions(TextDocumentContentOptions),
+    TextDocumentContentRegistrationOptions(TextDocumentContentRegistrationOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ParameterInformationLabel {
+    String(String),
+    Tuple((u32, u32)),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ParameterInformationDocumentation {
+    String(String),
+    MarkupContent(MarkupContent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NotebookCellTextDocumentFilterNotebook {
+    String(String),
+    NotebookDocumentFilter(NotebookDocumentFilter),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WorkspaceFoldersServerCapabilitiesChangeNotifications {
+    String(String),
+    Boolean(bool),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RelativePatternBaseUri {
+    WorkspaceFolder(WorkspaceFolder),
+    Uri(Uri),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ClientSemanticTokensRequestOptionsRange {
+    Boolean(bool),
+    Object(serde_json::Value),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ClientSemanticTokensRequestOptionsFull {
+    Boolean(bool),
+    ClientSemanticTokensRequestFullDelta(ClientSemanticTokensRequestFullDelta),
+}

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -795,22 +795,24 @@ impl From<Vec<InlayHintLabelPart>> for InlayHintLabel {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum InlayHintTooltip {
+pub enum StringOrMarkupContent {
     String(String),
     MarkupContent(MarkupContent),
 }
 
-impl From<String> for InlayHintTooltip {
+impl From<String> for StringOrMarkupContent {
     fn from(value: String) -> Self {
         Self::String(value)
     }
 }
 
-impl From<MarkupContent> for InlayHintTooltip {
+impl From<MarkupContent> for StringOrMarkupContent {
     fn from(value: MarkupContent) -> Self {
         Self::MarkupContent(value)
     }
 }
+
+pub type InlayHintTooltip = StringOrMarkupContent;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -895,24 +897,7 @@ impl From<Vec<String>> for DidChangeConfigurationSection {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CompletionItemDocumentation {
-    String(String),
-    MarkupContent(MarkupContent),
-}
-
-impl From<String> for CompletionItemDocumentation {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-impl From<MarkupContent> for CompletionItemDocumentation {
-    fn from(value: MarkupContent) -> Self {
-        Self::MarkupContent(value)
-    }
-}
+pub type CompletionItemDocumentation = StringOrMarkupContent;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1017,24 +1002,7 @@ impl From<AnnotatedTextEdit> for TextDocumentEditEditsItem {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum InlayHintLabelPartTooltip {
-    String(String),
-    MarkupContent(MarkupContent),
-}
-
-impl From<String> for InlayHintLabelPartTooltip {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-impl From<MarkupContent> for InlayHintLabelPartTooltip {
-    fn from(value: MarkupContent) -> Self {
-        Self::MarkupContent(value)
-    }
-}
+pub type InlayHintLabelPartTooltip = StringOrMarkupContent;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1716,24 +1684,7 @@ impl From<EditRangeWithInsertReplace> for CompletionItemDefaultsEditRange {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum SignatureInformationDocumentation {
-    String(String),
-    MarkupContent(MarkupContent),
-}
-
-impl From<String> for SignatureInformationDocumentation {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-impl From<MarkupContent> for SignatureInformationDocumentation {
-    fn from(value: MarkupContent) -> Self {
-        Self::MarkupContent(value)
-    }
-}
+pub type SignatureInformationDocumentation = StringOrMarkupContent;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1816,24 +1767,7 @@ impl From<(u32, u32)> for ParameterInformationLabel {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ParameterInformationDocumentation {
-    String(String),
-    MarkupContent(MarkupContent),
-}
-
-impl From<String> for ParameterInformationDocumentation {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-impl From<MarkupContent> for ParameterInformationDocumentation {
-    fn from(value: MarkupContent) -> Self {
-        Self::MarkupContent(value)
-    }
-}
+pub type ParameterInformationDocumentation = StringOrMarkupContent;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -318,14 +318,14 @@ pub enum WorkspaceSymbolResponse {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensRange {
-    Boolean(bool),
+    Bool(bool),
     Object(serde_json::Value),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticTokensFull {
-    Boolean(bool),
+    Bool(bool),
     /// `SemanticTokensFullDelta`.
     Delta(SemanticTokensFullDelta),
 }
@@ -459,7 +459,7 @@ pub enum NotebookDocumentSync {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum HoverProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `HoverOptions`.
     Options(HoverOptions),
 }
@@ -467,7 +467,7 @@ pub enum HoverProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeclarationProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DeclarationOptions`.
     Options(DeclarationOptions),
     /// `DeclarationRegistrationOptions`.
@@ -477,7 +477,7 @@ pub enum DeclarationProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DefinitionProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DefinitionOptions`.
     Options(DefinitionOptions),
 }
@@ -485,7 +485,7 @@ pub enum DefinitionProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TypeDefinitionProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `TypeDefinitionOptions`.
     Options(TypeDefinitionOptions),
     /// `TypeDefinitionRegistrationOptions`.
@@ -495,7 +495,7 @@ pub enum TypeDefinitionProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ImplementationProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `ImplementationOptions`.
     Options(ImplementationOptions),
     /// `ImplementationRegistrationOptions`.
@@ -505,14 +505,14 @@ pub enum ImplementationProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ReferencesProvider {
-    Boolean(bool),
+    Bool(bool),
     ReferenceOptions(ReferenceOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentHighlightProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DocumentHighlightOptions`.
     Options(DocumentHighlightOptions),
 }
@@ -520,7 +520,7 @@ pub enum DocumentHighlightProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentSymbolProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DocumentSymbolOptions`.
     Options(DocumentSymbolOptions),
 }
@@ -528,7 +528,7 @@ pub enum DocumentSymbolProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CodeActionProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `CodeActionOptions`.
     Options(CodeActionOptions),
 }
@@ -536,7 +536,7 @@ pub enum CodeActionProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ColorProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DocumentColorOptions`.
     Options(DocumentColorOptions),
     /// `DocumentColorRegistrationOptions`.
@@ -546,7 +546,7 @@ pub enum ColorProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceSymbolProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `WorkspaceSymbolOptions`.
     Options(WorkspaceSymbolOptions),
 }
@@ -554,7 +554,7 @@ pub enum WorkspaceSymbolProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentFormattingProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DocumentFormattingOptions`.
     Options(DocumentFormattingOptions),
 }
@@ -562,7 +562,7 @@ pub enum DocumentFormattingProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentRangeFormattingProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `DocumentRangeFormattingOptions`.
     Options(DocumentRangeFormattingOptions),
 }
@@ -570,7 +570,7 @@ pub enum DocumentRangeFormattingProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RenameProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `RenameOptions`.
     Options(RenameOptions),
 }
@@ -578,7 +578,7 @@ pub enum RenameProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FoldingRangeProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `FoldingRangeOptions`.
     Options(FoldingRangeOptions),
     /// `FoldingRangeRegistrationOptions`.
@@ -588,7 +588,7 @@ pub enum FoldingRangeProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SelectionRangeProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `SelectionRangeOptions`.
     Options(SelectionRangeOptions),
     /// `SelectionRangeRegistrationOptions`.
@@ -598,7 +598,7 @@ pub enum SelectionRangeProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CallHierarchyProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `CallHierarchyOptions`.
     Options(CallHierarchyOptions),
     /// `CallHierarchyRegistrationOptions`.
@@ -608,7 +608,7 @@ pub enum CallHierarchyProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LinkedEditingRangeProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `LinkedEditingRangeOptions`.
     Options(LinkedEditingRangeOptions),
     /// `LinkedEditingRangeRegistrationOptions`.
@@ -627,7 +627,7 @@ pub enum SemanticTokensProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum MonikerProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `MonikerOptions`.
     Options(MonikerOptions),
     /// `MonikerRegistrationOptions`.
@@ -637,7 +637,7 @@ pub enum MonikerProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TypeHierarchyProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `TypeHierarchyOptions`.
     Options(TypeHierarchyOptions),
     /// `TypeHierarchyRegistrationOptions`.
@@ -647,7 +647,7 @@ pub enum TypeHierarchyProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlineValueProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `InlineValueOptions`.
     Options(InlineValueOptions),
     /// `InlineValueRegistrationOptions`.
@@ -657,7 +657,7 @@ pub enum InlineValueProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlayHintProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `InlayHintOptions`.
     Options(InlayHintOptions),
     /// `InlayHintRegistrationOptions`.
@@ -677,7 +677,7 @@ pub enum DiagnosticProvider {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlineCompletionProvider {
-    Boolean(bool),
+    Bool(bool),
     /// `InlineCompletionOptions`.
     Options(InlineCompletionOptions),
 }
@@ -713,7 +713,7 @@ pub enum NotebookDocumentFilterNotebook {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TextDocumentSyncSave {
-    Boolean(bool),
+    Bool(bool),
     SaveOptions(SaveOptions),
 }
 
@@ -745,7 +745,7 @@ pub enum ParameterInformationDocumentation {
 #[serde(untagged)]
 pub enum WorkspaceFoldersChangeNotifications {
     String(String),
-    Boolean(bool),
+    Bool(bool),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -758,14 +758,14 @@ pub enum RelativePatternBaseUri {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ClientSemanticTokensRequestRange {
-    Boolean(bool),
+    Bool(bool),
     Object(serde_json::Value),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ClientSemanticTokensRequestFull {
-    Boolean(bool),
+    Bool(bool),
     /// `ClientSemanticTokensRequestFullDelta`.
     Delta(ClientSemanticTokensRequestFullDelta),
 }

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -41,9 +41,12 @@ pub enum Declaration {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlineValue {
-    InlineValueText(InlineValueText),
-    InlineValueVariableLookup(InlineValueVariableLookup),
-    InlineValueEvaluatableExpression(InlineValueEvaluatableExpression),
+    /// `InlineValueText`.
+    Text(InlineValueText),
+    /// `InlineValueVariableLookup`.
+    VariableLookup(InlineValueVariableLookup),
+    /// `InlineValueEvaluatableExpression`.
+    EvaluatableExpression(InlineValueEvaluatableExpression),
 }
 
 /// The result of a document diagnostic pull request. A report can
@@ -56,8 +59,10 @@ pub enum InlineValue {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DocumentDiagnosticReport {
-    RelatedFullDocumentDiagnosticReport(RelatedFullDocumentDiagnosticReport),
-    RelatedUnchangedDocumentDiagnosticReport(RelatedUnchangedDocumentDiagnosticReport),
+    /// `RelatedFullDocumentDiagnosticReport`.
+    Full(RelatedFullDocumentDiagnosticReport),
+    /// `RelatedUnchangedDocumentDiagnosticReport`.
+    Unchanged(RelatedUnchangedDocumentDiagnosticReport),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -81,8 +86,10 @@ pub enum ProgressToken {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceDocumentDiagnosticReport {
-    WorkspaceFullDocumentDiagnosticReport(WorkspaceFullDocumentDiagnosticReport),
-    WorkspaceUnchangedDocumentDiagnosticReport(WorkspaceUnchangedDocumentDiagnosticReport),
+    /// `WorkspaceFullDocumentDiagnosticReport`.
+    Full(WorkspaceFullDocumentDiagnosticReport),
+    /// `WorkspaceUnchangedDocumentDiagnosticReport`.
+    Unchanged(WorkspaceUnchangedDocumentDiagnosticReport),
 }
 
 /// An event describing a change to a text document. If only a text is provided
@@ -90,8 +97,10 @@ pub enum WorkspaceDocumentDiagnosticReport {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TextDocumentContentChangeEvent {
-    TextDocumentContentChangePartial(TextDocumentContentChangePartial),
-    TextDocumentContentChangeWholeDocument(TextDocumentContentChangeWholeDocument),
+    /// `TextDocumentContentChangePartial`.
+    Partial(TextDocumentContentChangePartial),
+    /// `TextDocumentContentChangeWholeDocument`.
+    WholeDocument(TextDocumentContentChangeWholeDocument),
 }
 
 /// MarkedString can be used to render human readable text. It is either a markdown string
@@ -153,9 +162,12 @@ pub enum GlobPattern {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TextDocumentFilter {
-    TextDocumentFilterLanguage(TextDocumentFilterLanguage),
-    TextDocumentFilterScheme(TextDocumentFilterScheme),
-    TextDocumentFilterPattern(TextDocumentFilterPattern),
+    /// `TextDocumentFilterLanguage`.
+    Language(TextDocumentFilterLanguage),
+    /// `TextDocumentFilterScheme`.
+    Scheme(TextDocumentFilterScheme),
+    /// `TextDocumentFilterPattern`.
+    Pattern(TextDocumentFilterPattern),
 }
 
 /// A notebook document filter denotes a notebook document by
@@ -166,9 +178,12 @@ pub enum TextDocumentFilter {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NotebookDocumentFilter {
-    NotebookDocumentFilterNotebookType(NotebookDocumentFilterNotebookType),
-    NotebookDocumentFilterScheme(NotebookDocumentFilterScheme),
-    NotebookDocumentFilterPattern(NotebookDocumentFilterPattern),
+    /// `NotebookDocumentFilterNotebookType`.
+    NotebookType(NotebookDocumentFilterNotebookType),
+    /// `NotebookDocumentFilterScheme`.
+    Scheme(NotebookDocumentFilterScheme),
+    /// `NotebookDocumentFilterPattern`.
+    Pattern(NotebookDocumentFilterPattern),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -236,15 +251,19 @@ pub enum WorkspaceDiagnosticRequestResult {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlineCompletionRequestResult {
-    InlineCompletionList(InlineCompletionList),
-    InlineCompletionItemList(Vec<InlineCompletionItem>),
+    /// `InlineCompletionList`.
+    List(InlineCompletionList),
+    /// `InlineCompletionItemList`.
+    ItemList(Vec<InlineCompletionItem>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CompletionRequestResult {
-    CompletionItemList(Vec<CompletionItem>),
-    CompletionList(CompletionList),
+    /// `CompletionItemList`.
+    ItemList(Vec<CompletionItem>),
+    /// `CompletionList`.
+    List(CompletionList),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -323,8 +342,10 @@ pub enum DocumentDiagnosticReportPartialResultRelatedDocumentsValue {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NotebookDocumentSyncRegistrationOptionsNotebookSelectorItem {
-    NotebookDocumentFilterWithNotebook(NotebookDocumentFilterWithNotebook),
-    NotebookDocumentFilterWithCells(NotebookDocumentFilterWithCells),
+    /// `NotebookDocumentFilterWithNotebook`.
+    Notebook(NotebookDocumentFilterWithNotebook),
+    /// `NotebookDocumentFilterWithCells`.
+    Cells(NotebookDocumentFilterWithCells),
 }
 
 #[cfg(feature = "proposed")]
@@ -423,22 +444,28 @@ pub enum RelatedUnchangedDocumentDiagnosticReportRelatedDocumentsValue {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NotebookDocumentSyncOptionsNotebookSelectorItem {
-    NotebookDocumentFilterWithNotebook(NotebookDocumentFilterWithNotebook),
-    NotebookDocumentFilterWithCells(NotebookDocumentFilterWithCells),
+    /// `NotebookDocumentFilterWithNotebook`.
+    Notebook(NotebookDocumentFilterWithNotebook),
+    /// `NotebookDocumentFilterWithCells`.
+    Cells(NotebookDocumentFilterWithCells),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesTextDocumentSync {
-    TextDocumentSyncOptions(TextDocumentSyncOptions),
-    TextDocumentSyncKind(TextDocumentSyncKind),
+    /// `TextDocumentSyncOptions`.
+    Options(TextDocumentSyncOptions),
+    /// `TextDocumentSyncKind`.
+    Kind(TextDocumentSyncKind),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesNotebookDocumentSync {
-    NotebookDocumentSyncOptions(NotebookDocumentSyncOptions),
-    NotebookDocumentSyncRegistrationOptions(NotebookDocumentSyncRegistrationOptions),
+    /// `NotebookDocumentSyncOptions`.
+    Options(NotebookDocumentSyncOptions),
+    /// `NotebookDocumentSyncRegistrationOptions`.
+    RegistrationOptions(NotebookDocumentSyncRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -452,8 +479,10 @@ pub enum ServerCapabilitiesHoverProvider {
 #[serde(untagged)]
 pub enum ServerCapabilitiesDeclarationProvider {
     Boolean(bool),
-    DeclarationOptions(DeclarationOptions),
-    DeclarationRegistrationOptions(DeclarationRegistrationOptions),
+    /// `DeclarationOptions`.
+    Options(DeclarationOptions),
+    /// `DeclarationRegistrationOptions`.
+    RegistrationOptions(DeclarationRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -467,16 +496,20 @@ pub enum ServerCapabilitiesDefinitionProvider {
 #[serde(untagged)]
 pub enum ServerCapabilitiesTypeDefinitionProvider {
     Boolean(bool),
-    TypeDefinitionOptions(TypeDefinitionOptions),
-    TypeDefinitionRegistrationOptions(TypeDefinitionRegistrationOptions),
+    /// `TypeDefinitionOptions`.
+    Options(TypeDefinitionOptions),
+    /// `TypeDefinitionRegistrationOptions`.
+    RegistrationOptions(TypeDefinitionRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesImplementationProvider {
     Boolean(bool),
-    ImplementationOptions(ImplementationOptions),
-    ImplementationRegistrationOptions(ImplementationRegistrationOptions),
+    /// `ImplementationOptions`.
+    Options(ImplementationOptions),
+    /// `ImplementationRegistrationOptions`.
+    RegistrationOptions(ImplementationRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -511,8 +544,10 @@ pub enum ServerCapabilitiesCodeActionProvider {
 #[serde(untagged)]
 pub enum ServerCapabilitiesColorProvider {
     Boolean(bool),
-    DocumentColorOptions(DocumentColorOptions),
-    DocumentColorRegistrationOptions(DocumentColorRegistrationOptions),
+    /// `DocumentColorOptions`.
+    Options(DocumentColorOptions),
+    /// `DocumentColorRegistrationOptions`.
+    RegistrationOptions(DocumentColorRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -547,78 +582,98 @@ pub enum ServerCapabilitiesRenameProvider {
 #[serde(untagged)]
 pub enum ServerCapabilitiesFoldingRangeProvider {
     Boolean(bool),
-    FoldingRangeOptions(FoldingRangeOptions),
-    FoldingRangeRegistrationOptions(FoldingRangeRegistrationOptions),
+    /// `FoldingRangeOptions`.
+    Options(FoldingRangeOptions),
+    /// `FoldingRangeRegistrationOptions`.
+    RegistrationOptions(FoldingRangeRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesSelectionRangeProvider {
     Boolean(bool),
-    SelectionRangeOptions(SelectionRangeOptions),
-    SelectionRangeRegistrationOptions(SelectionRangeRegistrationOptions),
+    /// `SelectionRangeOptions`.
+    Options(SelectionRangeOptions),
+    /// `SelectionRangeRegistrationOptions`.
+    RegistrationOptions(SelectionRangeRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesCallHierarchyProvider {
     Boolean(bool),
-    CallHierarchyOptions(CallHierarchyOptions),
-    CallHierarchyRegistrationOptions(CallHierarchyRegistrationOptions),
+    /// `CallHierarchyOptions`.
+    Options(CallHierarchyOptions),
+    /// `CallHierarchyRegistrationOptions`.
+    RegistrationOptions(CallHierarchyRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesLinkedEditingRangeProvider {
     Boolean(bool),
-    LinkedEditingRangeOptions(LinkedEditingRangeOptions),
-    LinkedEditingRangeRegistrationOptions(LinkedEditingRangeRegistrationOptions),
+    /// `LinkedEditingRangeOptions`.
+    Options(LinkedEditingRangeOptions),
+    /// `LinkedEditingRangeRegistrationOptions`.
+    RegistrationOptions(LinkedEditingRangeRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesSemanticTokensProvider {
-    SemanticTokensOptions(SemanticTokensOptions),
-    SemanticTokensRegistrationOptions(SemanticTokensRegistrationOptions),
+    /// `SemanticTokensOptions`.
+    Options(SemanticTokensOptions),
+    /// `SemanticTokensRegistrationOptions`.
+    RegistrationOptions(SemanticTokensRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesMonikerProvider {
     Boolean(bool),
-    MonikerOptions(MonikerOptions),
-    MonikerRegistrationOptions(MonikerRegistrationOptions),
+    /// `MonikerOptions`.
+    Options(MonikerOptions),
+    /// `MonikerRegistrationOptions`.
+    RegistrationOptions(MonikerRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesTypeHierarchyProvider {
     Boolean(bool),
-    TypeHierarchyOptions(TypeHierarchyOptions),
-    TypeHierarchyRegistrationOptions(TypeHierarchyRegistrationOptions),
+    /// `TypeHierarchyOptions`.
+    Options(TypeHierarchyOptions),
+    /// `TypeHierarchyRegistrationOptions`.
+    RegistrationOptions(TypeHierarchyRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesInlineValueProvider {
     Boolean(bool),
-    InlineValueOptions(InlineValueOptions),
-    InlineValueRegistrationOptions(InlineValueRegistrationOptions),
+    /// `InlineValueOptions`.
+    Options(InlineValueOptions),
+    /// `InlineValueRegistrationOptions`.
+    RegistrationOptions(InlineValueRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesInlayHintProvider {
     Boolean(bool),
-    InlayHintOptions(InlayHintOptions),
-    InlayHintRegistrationOptions(InlayHintRegistrationOptions),
+    /// `InlayHintOptions`.
+    Options(InlayHintOptions),
+    /// `InlayHintRegistrationOptions`.
+    RegistrationOptions(InlayHintRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ServerCapabilitiesDiagnosticProvider {
-    DiagnosticOptions(DiagnosticOptions),
-    DiagnosticRegistrationOptions(DiagnosticRegistrationOptions),
+    /// `DiagnosticOptions`.
+    Options(DiagnosticOptions),
+    /// `DiagnosticRegistrationOptions`.
+    RegistrationOptions(DiagnosticRegistrationOptions),
 }
 
 #[cfg(feature = "proposed")]
@@ -675,8 +730,10 @@ pub enum TextDocumentSyncOptionsSave {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceOptionsTextDocumentContent {
-    TextDocumentContentOptions(TextDocumentContentOptions),
-    TextDocumentContentRegistrationOptions(TextDocumentContentRegistrationOptions),
+    /// `TextDocumentContentOptions`.
+    Options(TextDocumentContentOptions),
+    /// `TextDocumentContentRegistrationOptions`.
+    RegistrationOptions(TextDocumentContentRegistrationOptions),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -198,7 +198,7 @@ pub enum NotebookDocumentFilter {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ImplementationRequestResult {
+pub enum ImplementationResponse {
     Definition(Definition),
     DefinitionLinkList(Vec<DefinitionLink>),
     LocationList(Vec<Location>),
@@ -206,7 +206,7 @@ pub enum ImplementationRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum TypeDefinitionRequestResult {
+pub enum TypeDefinitionResponse {
     Definition(Definition),
     DefinitionLinkList(Vec<DefinitionLink>),
     LocationList(Vec<Location>),
@@ -214,7 +214,7 @@ pub enum TypeDefinitionRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum DeclarationRequestResult {
+pub enum DeclarationResponse {
     Declaration(Declaration),
     DeclarationLinkList(Vec<DeclarationLink>),
     LocationList(Vec<Location>),
@@ -222,14 +222,14 @@ pub enum DeclarationRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum SemanticTokensRequestResult {
+pub enum SemanticTokensResponse {
     SemanticTokens(SemanticTokens),
     SemanticTokensPartialResult(SemanticTokensPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum SemanticTokensDeltaRequestResult {
+pub enum SemanticTokensDeltaResponse {
     SemanticTokens(SemanticTokens),
     SemanticTokensDelta(SemanticTokensDelta),
     SemanticTokensPartialResult(SemanticTokensPartialResult),
@@ -238,21 +238,21 @@ pub enum SemanticTokensDeltaRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum SemanticTokensRangeRequestResult {
+pub enum SemanticTokensRangeResponse {
     SemanticTokens(SemanticTokens),
     SemanticTokensPartialResult(SemanticTokensPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum DocumentDiagnosticRequestResult {
+pub enum DocumentDiagnosticResponse {
     DocumentDiagnosticReport(DocumentDiagnosticReport),
     DocumentDiagnosticReportPartialResult(DocumentDiagnosticReportPartialResult),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum WorkspaceDiagnosticRequestResult {
+pub enum WorkspaceDiagnosticResponse {
     WorkspaceDiagnosticReport(WorkspaceDiagnosticReport),
     WorkspaceDiagnosticReportPartialResult(WorkspaceDiagnosticReportPartialResult),
 }
@@ -260,7 +260,7 @@ pub enum WorkspaceDiagnosticRequestResult {
 #[cfg(feature = "proposed")]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum InlineCompletionRequestResult {
+pub enum InlineCompletionResponse {
     /// `InlineCompletionList`.
     List(InlineCompletionList),
     /// `InlineCompletionItemList`.
@@ -269,7 +269,7 @@ pub enum InlineCompletionRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum CompletionRequestResult {
+pub enum CompletionResponse {
     /// `CompletionItemList`.
     ItemList(Vec<CompletionItem>),
     /// `CompletionList`.
@@ -278,7 +278,7 @@ pub enum CompletionRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum DefinitionRequestResult {
+pub enum DefinitionResponse {
     Definition(Definition),
     DefinitionLinkList(Vec<DefinitionLink>),
     LocationList(Vec<Location>),
@@ -286,21 +286,21 @@ pub enum DefinitionRequestResult {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum DocumentSymbolRequestResult {
+pub enum DocumentSymbolResponse {
     SymbolInformationList(Vec<SymbolInformation>),
     DocumentSymbolList(Vec<DocumentSymbol>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum CodeActionRequestResultItem {
+pub enum CodeActionResponseItem {
     Command(Command),
     CodeAction(CodeAction),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum WorkspaceSymbolRequestResult {
+pub enum WorkspaceSymbolResponse {
     SymbolInformationList(Vec<SymbolInformation>),
     WorkspaceSymbolList(Vec<WorkspaceSymbol>),
 }

--- a/lspt/src/generated/unions.rs
+++ b/lspt/src/generated/unions.rs
@@ -6,9 +6,9 @@
 #![allow(rustdoc::invalid_codeblock_attributes)]
 #![allow(unused_imports)]
 
-use super::*;
 use crate::{HashMap, Uri};
 use serde::{Deserialize, Serialize};
+use super::*;
 
 /// The definition of a symbol represented as one or many {@link Location locations}.
 /// For most programming languages there is only one location at which a symbol is
@@ -23,6 +23,7 @@ pub enum Definition {
     LocationList(Vec<Location>),
 }
 
+
 /// The declaration of a symbol representation as one or many {@link Location locations}.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -30,6 +31,7 @@ pub enum Declaration {
     Location(Location),
     LocationList(Vec<Location>),
 }
+
 
 /// Inline value information can be provided by different means:
 /// - directly as a text value (class InlineValueText).
@@ -48,6 +50,7 @@ pub enum InlineValue {
     /// `InlineValueEvaluatableExpression`.
     EvaluatableExpression(InlineValueEvaluatableExpression),
 }
+
 
 /// The result of a document diagnostic pull request. A report can
 /// either be a full report containing all diagnostics for the
@@ -80,6 +83,7 @@ pub enum ProgressToken {
     String(String),
 }
 
+
 /// A workspace diagnostic document report.
 ///
 /// @since 3.17.0
@@ -92,6 +96,7 @@ pub enum WorkspaceDocumentDiagnosticReport {
     Unchanged(WorkspaceUnchangedDocumentDiagnosticReport),
 }
 
+
 /// An event describing a change to a text document. If only a text is provided
 /// it is considered to be the full content of the document.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -102,6 +107,7 @@ pub enum TextDocumentContentChangeEvent {
     /// `TextDocumentContentChangeWholeDocument`.
     WholeDocument(TextDocumentContentChangeWholeDocument),
 }
+
 
 /// MarkedString can be used to render human readable text. It is either a markdown string
 /// or a code-block that provides a language and a code snippet. The language identifier
@@ -122,6 +128,7 @@ pub enum MarkedString {
     MarkedStringWithLanguage(MarkedStringWithLanguage),
 }
 
+
 /// A document filter describes a top level text document or
 /// a notebook cell document.
 ///
@@ -133,6 +140,7 @@ pub enum DocumentFilter {
     NotebookCellTextDocumentFilter(NotebookCellTextDocumentFilter),
 }
 
+
 /// The glob pattern. Either a string pattern or a relative pattern.
 ///
 /// @since 3.17.0
@@ -142,6 +150,7 @@ pub enum GlobPattern {
     Pattern(Pattern),
     RelativePattern(RelativePattern),
 }
+
 
 /// A document filter denotes a document by different properties like
 /// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
@@ -169,6 +178,7 @@ pub enum TextDocumentFilter {
     /// `TextDocumentFilterPattern`.
     Pattern(TextDocumentFilterPattern),
 }
+
 
 /// A notebook document filter denotes a notebook document by
 /// different properties. The properties will be match

--- a/lspt/src/lib.rs
+++ b/lspt/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(rustdoc::invalid_html_tags)]
 
 pub use crate::generated::*;
-use serde::{Deserialize, Serialize};
 
 mod generated;
 
@@ -20,27 +19,3 @@ pub type HashMap<K, V> = std::collections::HashMap<K, V>;
 pub type Uri = url::Url;
 #[cfg(not(feature = "url"))]
 pub type Uri = String;
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum Union2<A, B> {
-    A(A),
-    B(B),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum Union3<A, B, C> {
-    A(A),
-    B(B),
-    C(C),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum Union4<A, B, C, D> {
-    A(A),
-    B(B),
-    C(C),
-    D(D),
-}


### PR DESCRIPTION
This replaces the generated generic `Union2` / `Union3` / `Union4` types with named enums for LSP union shapes. ~~Additionally, run `rustfmt` on generated files from the generator. (If unappropriate I can separate the fmt code into another pr)~~

There are still a few design issues that this PR does not try to fully solve yet:

- [x] Some generated enum and variant names are repetitive or quite long. For example, `WorkspaceDocumentDiagnosticReport::WorkspaceFullDocumentDiagnosticReport`.
- [ ] Some generated untagged enums have large variants. For example, code-action style unions can make the whole enum large and clippy warns about it. Should we use `Box` in this situation?

